### PR TITLE
fix 搜索框遮挡内容

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -111,7 +111,7 @@ export default {
 
 .staticSticky {
   position: fixed;
-  bottom: 10px;
+  bottom: 60px;
   right: 10px;
 }
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -2,16 +2,15 @@
 <div class="column is-gapless gap">
   <input class="input search is-rounded vtb-search" v-model="search" type="text" placeholder="查找主播~">
   <div class="columns">
-    <div class="column vtb-column">
-  </div>
-  <div class="column is-full-mobile is-11-tablet is-10-desktop is-three-fifths-widescreen is-7-fullhd">
-    <p v-if="cacheAge">数据缓存于: <span class="tag is-rounded is-info smallMargin">{{cacheAge}}</span></p>
-    <progress class="progress" max="100" v-if="!currentVtbs.length"></progress>
-    <transition-group name="flip-list">
-      <card v-for="vtb in rankLimit" :vtb="vtb" hover :key="vtb.mid" class="card"></card>
-    </transition-group>
-  </div>
-  <div class="column"></div>
+    <div class="column vtb-column"></div>
+    <div class="column is-full-mobile is-11-tablet is-10-desktop is-three-fifths-widescreen is-7-fullhd">
+      <p v-if="cacheAge">数据缓存于: <span class="tag is-rounded is-info smallMargin">{{cacheAge}}</span></p>
+      <progress class="progress" max="100" v-if="!currentVtbs.length"></progress>
+      <transition-group name="flip-list">
+        <card v-for="vtb in rankLimit" :vtb="vtb" hover :key="vtb.mid" class="card"></card>
+      </transition-group>
+    </div>
+    <div class="column"></div>
   </div>
 </div>
 </template>
@@ -96,9 +95,11 @@ export default {
 <style scoped>
 
 .vtb-search{
+  right: 10px;
+  bottom: 10px;
   box-shadow: inset 0 0.0625em 1em rgba(10, 10, 10, 0.05);
   outline: none;
-  border: none;
+  /* border: none; */
   width: 260px;
   position: fixed;
   z-index: 99;


### PR DESCRIPTION
提供一种解决方法

为了不影响原来的布局，暂时把搜索框移到了右下角，在解决中间尺寸窗口遮挡问题的同时方便移动端的单手操作

原来在右下角的加载动画也向上移动了50px，同时把搜索框的边框加了回来，之前确实不太好辨认

![Screenshot_20201027_192508_com microsoft emmx (1)](https://user-images.githubusercontent.com/28755005/97295419-35142c00-188a-11eb-861c-52a620233694.png)

<img width="1552" alt="CleanShot_2020-10-27_at_19 28 27@2x" src="https://user-images.githubusercontent.com/28755005/97295704-9e943a80-188a-11eb-9c93-e9796cdf9e25.png">

之后可以考虑修改为一个搜索的Button，focus后可以自动展开
