### PR TITLE
feat(search): add search shortcuts, highlight search box and search r…

### DIFF
--- a/src/components/card.vue
+++ b/src/components/card.vue
@@ -15,24 +15,33 @@
     <badge :status="status" v-if="info.uname"></badge>
   </div>
 
-  <div class="column is-12-mobile is-6-tablet is-6-desktop is-6-widescreen is-6-fullhd content smallBottomMarginTopBottomPadding">
-    <h4 class="noMargin">
-      <a :href="`https://live.bilibili.com/${roomid}`" class="tag is-link" v-if="liveStatus" target="_blank">
+  <div class="content column is-12-mobile is-6-tablet is-6-desktop is-6-widescreen is-6-fullhd smallBottomMarginTopBottomPadding">
+    <h4 class="is-fullwidth is-flex is-align-items-center">
+      <a :href="`https://live.bilibili.com/${roomid}`" class="tag card-badge is-link" v-if="liveStatus" target="_blank">
         直播中
       </a>
-      <a :href="`https://live.bilibili.com/${roomid}`" class="tag" v-else-if="roomid && livePage" target="_blank">
+      <a :href="`https://live.bilibili.com/${roomid}`" class="tag card-badge" v-else-if="roomid && livePage" target="_blank">
         没播
       </a>
-      {{uname}}
-      <router-link v-if="worm" to="about" class="tag" title="如何扩充名单: 关于">
+      <text-highlight style="margin: 0 2px;" :keyword="search" :text="uname.toString()" />
+      <!-- <router-link v-if="worm" to="about" class="tag" title="如何扩充名单: 关于">
+        未收录
+      </router-link> -->
+      <!-- <span>
+      <a :href="`https://space.bilibili.com/${mid}`" target="_blank" class="space tag ml-auto">
+        {{mid}}
+      </a></span> -->
+    </h4>
+    <h4 class="is-fullwidth is-flex is-align-items-center is-justify-content-flex-start" >
+      <router-link v-if="worm" to="about" class="tag card-badge" title="如何扩充名单: 关于">
         未收录
       </router-link>
-      <a :href="`https://space.bilibili.com/${mid}`" target="_blank" class="space tag">
+      <a :href="`https://space.bilibili.com/${mid}`" target="_blank" class="tag card-badge ml-auto">
         {{mid}}
       </a>
     </h4>
     <span v-if="liveStatus" class="el-icon-ship">{{title}}</span>
-    <p>{{sign}}</p>
+    <text-highlight :keyword="search" :text="sign.toString()" />
     <hr class="is-hidden-tablet">
   </div>
 
@@ -46,15 +55,21 @@
 
 <script>
 import badge from '@/components/badge'
+import textHighlight from '@/components/textHighlight'
 import moment from 'moment'
 
 export default {
   components: {
     badge,
+    'text-highlight': textHighlight
   },
   props: {
     vtb: Object,
     hover: Boolean,
+    search: {
+      type: String,
+      default: ''
+    }
   },
   computed: {
     info: function() {
@@ -147,8 +162,11 @@ export default {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.12), 0 0 6px rgba(0, 0, 0, 0.04);
 }
 
-.noMargin {
-  margin: 0;
+.content h4:first-of-type{
+  margin-bottom: 4px;
+}
+.card-badge {
+  margin: 0 2px;
 }
 
 .smallBottomMarginTopBottomPadding {
@@ -159,10 +177,6 @@ export default {
 
 .smallMargin {
   margin-bottom: 8px;
-}
-
-.space {
-  float: right;
 }
 
 .discover {

--- a/src/components/textHighlight.vue
+++ b/src/components/textHighlight.vue
@@ -1,0 +1,75 @@
+<template>
+    <span class="searchHighlight">
+        <span v-if="keyword != ''" class="searchHighlightRow">
+            <span v-for="fragment in highlightedText" :key="fragment.id"
+                :class="{ searchHighlightLighted: fragment.highlight }" v-text="fragment.text">
+            </span>
+        </span>
+        <p v-else v-text="text" class="searchHighlightRow">
+        </p>
+    </span>
+</template>
+
+<script>
+export default {
+    props: {
+        text: {
+            type: String,
+            default: ''
+        },
+        keyword: {
+            type: String,
+            default: ''
+        }
+    },
+    computed: {
+        highlightedText() {
+            // 正则匹配切分文本中的高亮词
+            if (this.text && this.keyword && this.text != '' && this.keyword != ' ') {
+                const fragments = [];
+                let remainingText = this.text;
+                const keywordRegex = new RegExp(this.keyword, "gi");
+                while (remainingText.length > 0) {
+                    const match = keywordRegex.exec(remainingText);
+                    if (match) {
+                        const startIndex = match.index;
+                        const endIndex = match.index + match[0].length;
+                        if (startIndex > 0) {
+                            fragments.push({
+                                text: remainingText.substring(0, startIndex),
+                                highlight: false
+                            });
+                        }
+                        fragments.push({
+                            text: remainingText.substring(startIndex, endIndex),
+                            highlight: true
+                        });
+                        remainingText = remainingText.substring(endIndex);
+                    } else {
+                        fragments.push({
+                            text: remainingText,
+                            highlight: false
+                        });
+                        break;
+                    }
+                }
+                return fragments;
+            }
+        }
+    }
+}
+</script>
+
+<style scoped>
+.searchHighlight{
+    display: inline;
+    width: auto;
+}
+.searchHighlightRow {
+    display: inline;
+}
+
+.searchHighlightLighted {
+    color: #409eff
+}
+</style>


### PR DESCRIPTION
#463

绑定搜索快捷键，增加搜索框高亮样式，搜索结果文本高亮
调整卡片css样式

1.  ctrl+F或Cmd+F唤醒搜索框
2. 增加搜索框被唤醒时的居中高亮样式（摁ESC退出搜索框高亮）
3. 搜索结果文本优化（正则匹配关键词高亮）
4. 修改卡片css样式防止文字过长

<img width="1084" alt="image" src="https://github.com/dd-center/vtbs.moe/assets/96223880/ada1f51f-ed70-4c8a-a672-75d76d464525">
