### PR TITLE
feat(npmrc): update npmmirror

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+registry=https://registry.npmmirror.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1253,7 +1253,7 @@
     },
     "node_modules/@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/@intervolga/optimize-cssnano-plugin/download/@intervolga/optimize-cssnano-plugin-1.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@intervolga/optimize-cssnano-plugin/download/@intervolga/optimize-cssnano-plugin-1.0.6.tgz",
       "integrity": "sha1-vnx4RhKLiPapsdEmGgrQbrXA/fg=",
       "dev": true,
       "dependencies": {
@@ -1475,7 +1475,7 @@
     },
     "node_modules/@soda/friendly-errors-webpack-plugin": {
       "version": "1.8.0",
-      "resolved": "https://registry.npm.taobao.org/@soda/friendly-errors-webpack-plugin/download/@soda/friendly-errors-webpack-plugin-1.8.0.tgz?cache=0&sync_timestamp=1607927398894&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40soda%2Ffriendly-errors-webpack-plugin%2Fdownload%2F%40soda%2Ffriendly-errors-webpack-plugin-1.8.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@soda/friendly-errors-webpack-plugin/download/@soda/friendly-errors-webpack-plugin-1.8.0.tgz?cache=0&sync_timestamp=1607927398894&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40soda%2Ffriendly-errors-webpack-plugin%2Fdownload%2F%40soda%2Ffriendly-errors-webpack-plugin-1.8.0.tgz",
       "integrity": "sha1-hHUdgqkwGdXJLAzw5FrFkIfNIkA=",
       "dev": true,
       "dependencies": {
@@ -1493,7 +1493,7 @@
     },
     "node_modules/@soda/friendly-errors-webpack-plugin/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/download/ansi-regex-4.1.0.tgz",
       "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
       "dev": true,
       "engines": {
@@ -1502,7 +1502,7 @@
     },
     "node_modules/@soda/friendly-errors-webpack-plugin/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-5.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-5.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-5.2.0.tgz",
       "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
       "dev": true,
       "dependencies": {
@@ -1514,7 +1514,7 @@
     },
     "node_modules/@soda/get-current-script": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/@soda/get-current-script/download/@soda/get-current-script-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@soda/get-current-script/download/@soda/get-current-script-1.0.2.tgz",
       "integrity": "sha1-pTUV2yXYA4N0OBtzryC7Ty5QjYc=",
       "dev": true
     },
@@ -1580,7 +1580,7 @@
     },
     "node_modules/@types/anymatch": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/@types/anymatch/download/@types/anymatch-1.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/anymatch/download/@types/anymatch-1.3.1.tgz",
       "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
       "dev": true
     },
@@ -1628,7 +1628,7 @@
     },
     "node_modules/@types/connect-history-api-fallback": {
       "version": "1.3.3",
-      "resolved": "https://registry.npm.taobao.org/@types/connect-history-api-fallback/download/@types/connect-history-api-fallback-1.3.3.tgz?cache=0&sync_timestamp=1605052862677&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fconnect-history-api-fallback%2Fdownload%2F%40types%2Fconnect-history-api-fallback-1.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/connect-history-api-fallback/download/@types/connect-history-api-fallback-1.3.3.tgz?cache=0&sync_timestamp=1605052862677&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fconnect-history-api-fallback%2Fdownload%2F%40types%2Fconnect-history-api-fallback-1.3.3.tgz",
       "integrity": "sha1-R3K3m4tTGF8PTJ3qsJI2uvdu47Q=",
       "dev": true,
       "dependencies": {
@@ -1761,7 +1761,7 @@
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.5",
-      "resolved": "https://registry.npm.taobao.org/@types/http-proxy/download/@types/http-proxy-1.17.5.tgz?cache=0&sync_timestamp=1610728394965&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fhttp-proxy%2Fdownload%2F%40types%2Fhttp-proxy-1.17.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/http-proxy/download/@types/http-proxy-1.17.5.tgz?cache=0&sync_timestamp=1610728394965&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fhttp-proxy%2Fdownload%2F%40types%2Fhttp-proxy-1.17.5.tgz",
       "integrity": "sha1-wgPF5uncaCDSekDrHlEccKIgQj0=",
       "dev": true,
       "dependencies": {
@@ -1770,7 +1770,7 @@
     },
     "node_modules/@types/http-proxy-middleware": {
       "version": "0.19.3",
-      "resolved": "https://registry.npm.taobao.org/@types/http-proxy-middleware/download/@types/http-proxy-middleware-0.19.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/http-proxy-middleware/download/@types/http-proxy-middleware-0.19.3.tgz",
       "integrity": "sha1-suuW+8D5rHJQtdnExTqt4ElJfQM=",
       "dev": true,
       "dependencies": {
@@ -1880,7 +1880,7 @@
     },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/@types/minimist/download/@types/minimist-1.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/minimist/download/@types/minimist-1.2.1.tgz",
       "integrity": "sha1-KD9mn/dte4Jg34q3pCYsyD2YglY=",
       "dev": true
     },
@@ -1903,7 +1903,7 @@
     },
     "node_modules/@types/q": {
       "version": "1.5.4",
-      "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.4.tgz?cache=0&sync_timestamp=1605055234302&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fq%2Fdownload%2F%40types%2Fq-1.5.4.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/q/download/@types/q-1.5.4.tgz?cache=0&sync_timestamp=1605055234302&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fq%2Fdownload%2F%40types%2Fq-1.5.4.tgz",
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "dev": true
     },
@@ -1948,7 +1948,7 @@
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/@types/source-list-map/download/@types/source-list-map-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/source-list-map/download/@types/source-list-map-0.1.2.tgz",
       "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
       "dev": true
     },
@@ -1965,13 +1965,13 @@
     },
     "node_modules/@types/tapable": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/@types/tapable/download/@types/tapable-1.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/tapable/download/@types/tapable-1.0.6.tgz",
       "integrity": "sha1-qcpLcKGLJwzLK8Cqr+/R1Ia36nQ=",
       "dev": true
     },
     "node_modules/@types/uglify-js": {
       "version": "3.12.0",
-      "resolved": "https://registry.npm.taobao.org/@types/uglify-js/download/@types/uglify-js-3.12.0.tgz?cache=0&sync_timestamp=1612680934348&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fuglify-js%2Fdownload%2F%40types%2Fuglify-js-3.12.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/uglify-js/download/@types/uglify-js-3.12.0.tgz?cache=0&sync_timestamp=1612680934348&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fuglify-js%2Fdownload%2F%40types%2Fuglify-js-3.12.0.tgz",
       "integrity": "sha1-K7BhwmlEFiDUa5RjUMjxbVLvN8U=",
       "dev": true,
       "dependencies": {
@@ -1980,7 +1980,7 @@
     },
     "node_modules/@types/uglify-js/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -1989,7 +1989,7 @@
     },
     "node_modules/@types/webpack": {
       "version": "4.41.26",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack/download/@types/webpack-4.41.26.tgz?cache=0&sync_timestamp=1610402050021&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fwebpack%2Fdownload%2F%40types%2Fwebpack-4.41.26.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/webpack/download/@types/webpack-4.41.26.tgz?cache=0&sync_timestamp=1610402050021&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fwebpack%2Fdownload%2F%40types%2Fwebpack-4.41.26.tgz",
       "integrity": "sha1-J6MNfVMeFkifnHYHx0e+a8GkWe8=",
       "dev": true,
       "dependencies": {
@@ -2003,7 +2003,7 @@
     },
     "node_modules/@types/webpack-dev-server": {
       "version": "3.11.1",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack-dev-server/download/@types/webpack-dev-server-3.11.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/webpack-dev-server/download/@types/webpack-dev-server-3.11.1.tgz",
       "integrity": "sha1-+PTawdoibVML0VodXcNLI7p2bMs=",
       "dev": true,
       "dependencies": {
@@ -2016,7 +2016,7 @@
     },
     "node_modules/@types/webpack-sources": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack-sources/download/@types/webpack-sources-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/webpack-sources/download/@types/webpack-sources-2.1.0.tgz",
       "integrity": "sha1-iIKwvWLR4M5i8YPQ0Bty5ugujBA=",
       "dev": true,
       "dependencies": {
@@ -2027,7 +2027,7 @@
     },
     "node_modules/@types/webpack-sources/node_modules/source-map": {
       "version": "0.7.3",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.7.3.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.7.3.tgz",
       "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
       "dev": true,
       "engines": {
@@ -2036,7 +2036,7 @@
     },
     "node_modules/@types/webpack/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -3062,7 +3062,7 @@
     },
     "node_modules/@vue/cli-service/node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
+      "resolved": "https://registry.npmmirror.com/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
       "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
       "dev": true,
       "bin": {
@@ -3074,7 +3074,7 @@
     },
     "node_modules/@vue/cli-service/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-7.0.1.tgz?cache=0&sync_timestamp=1611075495956&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-7.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/fs-extra/download/fs-extra-7.0.1.tgz?cache=0&sync_timestamp=1611075495956&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-7.0.1.tgz",
       "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "dependencies": {
@@ -3159,7 +3159,7 @@
     },
     "node_modules/@vue/component-compiler-utils": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/component-compiler-utils/download/@vue/component-compiler-utils-3.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@vue/component-compiler-utils/download/@vue/component-compiler-utils-3.2.0.tgz",
       "integrity": "sha1-j4UYLO7Sjps8dTE95mn4MWbRHl0=",
       "dev": true,
       "dependencies": {
@@ -3178,13 +3178,13 @@
     },
     "node_modules/@vue/component-compiler-utils/node_modules/hash-sum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-1.0.2.tgz",
       "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
       "dev": true
     },
     "node_modules/@vue/component-compiler-utils/node_modules/lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+      "resolved": "https://registry.npmmirror.com/lru-cache/download/lru-cache-4.1.5.tgz",
       "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
       "dev": true,
       "dependencies": {
@@ -3194,7 +3194,7 @@
     },
     "node_modules/@vue/component-compiler-utils/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -3203,13 +3203,13 @@
     },
     "node_modules/@vue/component-compiler-utils/node_modules/yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/yallist/download/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "node_modules/@vue/preload-webpack-plugin": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/@vue/preload-webpack-plugin/download/@vue/preload-webpack-plugin-1.1.2.tgz?cache=0&sync_timestamp=1613215046917&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fpreload-webpack-plugin%2Fdownload%2F%40vue%2Fpreload-webpack-plugin-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@vue/preload-webpack-plugin/download/@vue/preload-webpack-plugin-1.1.2.tgz?cache=0&sync_timestamp=1613215046917&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fpreload-webpack-plugin%2Fdownload%2F%40vue%2Fpreload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha1-zrkktOyzucQ4ccekKaAvhCPmIas=",
       "dev": true,
       "engines": {
@@ -3222,7 +3222,7 @@
     },
     "node_modules/@vue/web-component-wrapper": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/web-component-wrapper/download/@vue/web-component-wrapper-1.3.0.tgz?cache=0&sync_timestamp=1613216636926&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fweb-component-wrapper%2Fdownload%2F%40vue%2Fweb-component-wrapper-1.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@vue/web-component-wrapper/download/@vue/web-component-wrapper-1.3.0.tgz?cache=0&sync_timestamp=1613216636926&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fweb-component-wrapper%2Fdownload%2F%40vue%2Fweb-component-wrapper-1.3.0.tgz",
       "integrity": "sha1-trQKdiVCnSvXwigd26YB7QXcfxo=",
       "dev": true
     },
@@ -3547,7 +3547,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/acorn-walk/download/acorn-walk-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/acorn-walk/download/acorn-walk-7.2.0.tgz",
       "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
       "dev": true,
       "engines": {
@@ -3556,7 +3556,7 @@
     },
     "node_modules/address": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/address/download/address-1.1.2.tgz?cache=0&sync_timestamp=1593529661616&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Faddress%2Fdownload%2Faddress-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/address/download/address-1.1.2.tgz?cache=0&sync_timestamp=1593529661616&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Faddress%2Fdownload%2Faddress-1.1.2.tgz",
       "integrity": "sha1-vxEWycdYxRt6kz0pa3LCIe2UKLY=",
       "dev": true,
       "engines": {
@@ -3594,7 +3594,7 @@
     },
     "node_modules/alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
@@ -3609,7 +3609,7 @@
     },
     "node_modules/ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://registry.npm.taobao.org/ansi-html/download/ansi-html-0.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-html/download/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true,
       "engines": [
@@ -3678,7 +3678,7 @@
     },
     "node_modules/arch": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/arch/download/arch-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/arch/download/arch-2.2.0.tgz",
       "integrity": "sha1-G8R4GPMFdk8jqzMGsL/AhsWinRE=",
       "dev": true
     },
@@ -3732,7 +3732,7 @@
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/array-flatten/download/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -3908,7 +3908,7 @@
     },
     "node_modules/autoprefixer": {
       "version": "9.8.6",
-      "resolved": "https://registry.npm.taobao.org/autoprefixer/download/autoprefixer-9.8.6.tgz",
+      "resolved": "https://registry.npmmirror.com/autoprefixer/download/autoprefixer-9.8.6.tgz",
       "integrity": "sha1-O3NZTKG/kmYyDFrPFYjXTep0IQ8=",
       "dev": true,
       "dependencies": {
@@ -4091,7 +4091,7 @@
     },
     "node_modules/batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/batch/download/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/batch/download/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
@@ -4106,7 +4106,7 @@
     },
     "node_modules/bfj": {
       "version": "6.1.2",
-      "resolved": "https://registry.npm.taobao.org/bfj/download/bfj-6.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/bfj/download/bfj-6.1.2.tgz",
       "integrity": "sha1-MlyGGoIryzWKQceKM7jm4ght3n8=",
       "dev": true,
       "dependencies": {
@@ -4212,7 +4212,7 @@
     },
     "node_modules/body-parser": {
       "version": "1.19.0",
-      "resolved": "https://registry.npm.taobao.org/body-parser/download/body-parser-1.19.0.tgz",
+      "resolved": "https://registry.npmmirror.com/body-parser/download/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "dev": true,
       "dependencies": {
@@ -4233,7 +4233,7 @@
     },
     "node_modules/body-parser/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -4242,7 +4242,7 @@
     },
     "node_modules/body-parser/node_modules/http-errors": {
       "version": "1.7.2",
-      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "dev": true,
       "dependencies": {
@@ -4258,19 +4258,19 @@
     },
     "node_modules/body-parser/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/body-parser/node_modules/qs": {
       "version": "6.7.0",
-      "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
       "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
       "dev": true,
       "engines": {
@@ -4279,13 +4279,13 @@
     },
     "node_modules/body-parser/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
     "node_modules/bonjour": {
       "version": "3.5.0",
-      "resolved": "https://registry.npm.taobao.org/bonjour/download/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/bonjour/download/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "dependencies": {
@@ -4299,13 +4299,13 @@
     },
     "node_modules/bonjour/node_modules/array-flatten": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/array-flatten/download/array-flatten-2.1.2.tgz",
       "integrity": "sha1-JO+AoowaiTYX4hSbDG0NeIKTsJk=",
       "dev": true
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/boolbase/download/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
@@ -4500,7 +4500,7 @@
     },
     "node_modules/buffer-indexof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/buffer-indexof/download/buffer-indexof-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/buffer-indexof/download/buffer-indexof-1.1.1.tgz",
       "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
       "dev": true
     },
@@ -4541,7 +4541,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/bytes/download/bytes-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/bytes/download/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
       "dev": true,
       "engines": {
@@ -4774,7 +4774,7 @@
     },
     "node_modules/caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/caller-callsite/download/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/caller-callsite/download/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "dependencies": {
@@ -4786,7 +4786,7 @@
     },
     "node_modules/caller-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/caller-path/download/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/caller-path/download/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "dependencies": {
@@ -4798,7 +4798,7 @@
     },
     "node_modules/callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/callsites/download/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true,
       "engines": {
@@ -4807,7 +4807,7 @@
     },
     "node_modules/camel-case": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/camel-case/download/camel-case-3.0.0.tgz?cache=0&sync_timestamp=1606869170809&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamel-case%2Fdownload%2Fcamel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/camel-case/download/camel-case-3.0.0.tgz?cache=0&sync_timestamp=1606869170809&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamel-case%2Fdownload%2Fcamel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "dependencies": {
@@ -4826,7 +4826,7 @@
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/caniuse-api/download/caniuse-api-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/caniuse-api/download/caniuse-api-3.0.0.tgz",
       "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
       "dev": true,
       "dependencies": {
@@ -4854,7 +4854,7 @@
     },
     "node_modules/case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
       "integrity": "sha1-I6xhPMmoVuT4j/i7c7u16YmCXPc=",
       "dev": true,
       "engines": {
@@ -4918,7 +4918,7 @@
     },
     "node_modules/check-types": {
       "version": "8.0.3",
-      "resolved": "https://registry.npm.taobao.org/check-types/download/check-types-8.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/check-types/download/check-types-8.0.3.tgz",
       "integrity": "sha1-M1bMoZyIlUTy16le1JzlCKDs9VI=",
       "dev": true
     },
@@ -5077,7 +5077,7 @@
     },
     "node_modules/clean-css": {
       "version": "4.2.3",
-      "resolved": "https://registry.npm.taobao.org/clean-css/download/clean-css-4.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/clean-css/download/clean-css-4.2.3.tgz",
       "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
       "dev": true,
       "dependencies": {
@@ -5089,7 +5089,7 @@
     },
     "node_modules/clean-css/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -5110,7 +5110,7 @@
     },
     "node_modules/cli-highlight": {
       "version": "2.1.10",
-      "resolved": "https://registry.npm.taobao.org/cli-highlight/download/cli-highlight-2.1.10.tgz?cache=0&sync_timestamp=1610119762804&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-highlight%2Fdownload%2Fcli-highlight-2.1.10.tgz",
+      "resolved": "https://registry.npmmirror.com/cli-highlight/download/cli-highlight-2.1.10.tgz?cache=0&sync_timestamp=1610119762804&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-highlight%2Fdownload%2Fcli-highlight-2.1.10.tgz",
       "integrity": "sha1-JqCH2pIJ3OT8uM9UJ9yXzZasFzo=",
       "dev": true,
       "dependencies": {
@@ -5131,7 +5131,7 @@
     },
     "node_modules/cli-highlight/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-5.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/download/ansi-regex-5.0.0.tgz",
       "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
       "dev": true,
       "engines": {
@@ -5140,7 +5140,7 @@
     },
     "node_modules/cli-highlight/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "dependencies": {
@@ -5152,7 +5152,7 @@
     },
     "node_modules/cli-highlight/node_modules/chalk": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
       "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
       "dev": true,
       "dependencies": {
@@ -5165,7 +5165,7 @@
     },
     "node_modules/cli-highlight/node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-7.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/cliui/download/cliui-7.0.4.tgz",
       "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
       "dev": true,
       "dependencies": {
@@ -5176,7 +5176,7 @@
     },
     "node_modules/cli-highlight/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/color-convert/download/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
       "dependencies": {
@@ -5188,13 +5188,13 @@
     },
     "node_modules/cli-highlight/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/color-name/download/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true
     },
     "node_modules/cli-highlight/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/has-flag/download/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "engines": {
@@ -5203,7 +5203,7 @@
     },
     "node_modules/cli-highlight/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true,
       "engines": {
@@ -5212,7 +5212,7 @@
     },
     "node_modules/cli-highlight/node_modules/string-width": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-4.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/string-width/download/string-width-4.2.0.tgz",
       "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
       "dev": true,
       "dependencies": {
@@ -5226,7 +5226,7 @@
     },
     "node_modules/cli-highlight/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-6.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-6.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-6.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-6.0.0.tgz",
       "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
       "dev": true,
       "dependencies": {
@@ -5238,7 +5238,7 @@
     },
     "node_modules/cli-highlight/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "dependencies": {
@@ -5250,7 +5250,7 @@
     },
     "node_modules/cli-highlight/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/download/wrap-ansi-7.0.0.tgz",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
       "dev": true,
       "dependencies": {
@@ -5264,7 +5264,7 @@
     },
     "node_modules/cli-highlight/node_modules/y18n": {
       "version": "5.0.5",
-      "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-5.0.5.tgz?cache=0&sync_timestamp=1609798693274&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-5.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/y18n/download/y18n-5.0.5.tgz?cache=0&sync_timestamp=1609798693274&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-5.0.5.tgz",
       "integrity": "sha1-h2nsCNA7HqLfJQCs71YXQ7u5qxg=",
       "dev": true,
       "engines": {
@@ -5273,7 +5273,7 @@
     },
     "node_modules/cli-highlight/node_modules/yargs": {
       "version": "16.2.0",
-      "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-16.2.0.tgz?cache=0&sync_timestamp=1610219751347&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-16.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/yargs/download/yargs-16.2.0.tgz?cache=0&sync_timestamp=1610219751347&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-16.2.0.tgz",
       "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
       "dev": true,
       "dependencies": {
@@ -5291,7 +5291,7 @@
     },
     "node_modules/cli-highlight/node_modules/yargs-parser": {
       "version": "20.2.5",
-      "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-20.2.5.tgz",
+      "resolved": "https://registry.npmmirror.com/yargs-parser/download/yargs-parser-20.2.5.tgz",
       "integrity": "sha1-XTdykUbT+JTzn8lLZ5b1sjlRMYY=",
       "dev": true,
       "engines": {
@@ -5312,7 +5312,7 @@
     },
     "node_modules/clipboardy": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/clipboardy/download/clipboardy-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/clipboardy/download/clipboardy-2.3.0.tgz",
       "integrity": "sha1-PCkDZQxo5GqRs4iYW8J3QofbopA=",
       "dev": true,
       "dependencies": {
@@ -5326,7 +5326,7 @@
     },
     "node_modules/clipboardy/node_modules/is-wsl": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-wsl/download/is-wsl-2.2.0.tgz",
       "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
       "dev": true,
       "dependencies": {
@@ -5441,7 +5441,7 @@
     },
     "node_modules/coa": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/coa/download/coa-2.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/coa/download/coa-2.0.2.tgz",
       "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
       "dev": true,
       "dependencies": {
@@ -5558,7 +5558,7 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "resolved": "https://registry.npm.taobao.org/compressible/download/compressible-2.0.18.tgz",
+      "resolved": "https://registry.npmmirror.com/compressible/download/compressible-2.0.18.tgz",
       "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
       "dev": true,
       "dependencies": {
@@ -5570,7 +5570,7 @@
     },
     "node_modules/compression": {
       "version": "1.7.4",
-      "resolved": "https://registry.npm.taobao.org/compression/download/compression-1.7.4.tgz",
+      "resolved": "https://registry.npmmirror.com/compression/download/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "dev": true,
       "dependencies": {
@@ -5588,7 +5588,7 @@
     },
     "node_modules/compression/node_modules/bytes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/bytes/download/bytes-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/bytes/download/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true,
       "engines": {
@@ -5597,7 +5597,7 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -5606,7 +5606,7 @@
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
@@ -5663,7 +5663,7 @@
     },
     "node_modules/connect-history-api-fallback": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/connect-history-api-fallback/download/connect-history-api-fallback-1.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/connect-history-api-fallback/download/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha1-izIIk1kwjRERFdgcrT/Oq4iPl7w=",
       "dev": true,
       "engines": {
@@ -5678,7 +5678,7 @@
     },
     "node_modules/consolidate": {
       "version": "0.15.1",
-      "resolved": "https://registry.npm.taobao.org/consolidate/download/consolidate-0.15.1.tgz",
+      "resolved": "https://registry.npmmirror.com/consolidate/download/consolidate-0.15.1.tgz",
       "integrity": "sha1-IasEMjXHGgfUXZqtmFk7DbpWurc=",
       "dev": true,
       "dependencies": {
@@ -5732,7 +5732,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/cookie-signature/download/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/download/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
@@ -5924,7 +5924,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://registry.npm.taobao.org/cosmiconfig/download/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cosmiconfig/download/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "dev": true,
       "dependencies": {
@@ -5939,7 +5939,7 @@
     },
     "node_modules/cosmiconfig/node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-4.0.0.tgz?cache=0&sync_timestamp=1610966642419&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse-json%2Fdownload%2Fparse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/parse-json/download/parse-json-4.0.0.tgz?cache=0&sync_timestamp=1610966642419&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse-json%2Fdownload%2Fparse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "dependencies": {
@@ -6081,7 +6081,7 @@
     },
     "node_modules/css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npm.taobao.org/css-color-names/download/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/css-color-names/download/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true,
       "engines": {
@@ -6090,7 +6090,7 @@
     },
     "node_modules/css-declaration-sorter": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/css-declaration-sorter/download/css-declaration-sorter-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/css-declaration-sorter/download/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
       "dev": true,
       "dependencies": {
@@ -6103,7 +6103,7 @@
     },
     "node_modules/css-loader": {
       "version": "3.6.0",
-      "resolved": "https://registry.npm.taobao.org/css-loader/download/css-loader-3.6.0.tgz?cache=0&sync_timestamp=1612791290346&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-loader%2Fdownload%2Fcss-loader-3.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/css-loader/download/css-loader-3.6.0.tgz?cache=0&sync_timestamp=1612791290346&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-loader%2Fdownload%2Fcss-loader-3.6.0.tgz",
       "integrity": "sha1-Lkssfm4tJ/jI8o9hv/zS5ske9kU=",
       "dev": true,
       "dependencies": {
@@ -6130,7 +6130,7 @@
     },
     "node_modules/css-loader/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npm.taobao.org/camelcase/download/camelcase-5.3.1.tgz?cache=0&sync_timestamp=1603921884289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamelcase%2Fdownload%2Fcamelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/camelcase/download/camelcase-5.3.1.tgz?cache=0&sync_timestamp=1603921884289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamelcase%2Fdownload%2Fcamelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true,
       "engines": {
@@ -6139,7 +6139,7 @@
     },
     "node_modules/css-loader/node_modules/semver": {
       "version": "6.3.0",
-      "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true,
       "bin": {
@@ -6148,7 +6148,7 @@
     },
     "node_modules/css-select": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/css-select/download/css-select-2.1.0.tgz?cache=0&sync_timestamp=1608486296143&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-select%2Fdownload%2Fcss-select-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/css-select/download/css-select-2.1.0.tgz?cache=0&sync_timestamp=1608486296143&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-select%2Fdownload%2Fcss-select-2.1.0.tgz",
       "integrity": "sha1-ajRlM1ZjWTSoG6ymjQJVQyEF2+8=",
       "dev": true,
       "dependencies": {
@@ -6160,13 +6160,13 @@
     },
     "node_modules/css-select-base-adapter": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/css-select-base-adapter/download/css-select-base-adapter-0.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/css-select-base-adapter/download/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc=",
       "dev": true
     },
     "node_modules/css-tree": {
       "version": "1.0.0-alpha.37",
-      "resolved": "https://registry.npm.taobao.org/css-tree/download/css-tree-1.0.0-alpha.37.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.0.0-alpha.37.tgz",
+      "resolved": "https://registry.npmmirror.com/css-tree/download/css-tree-1.0.0-alpha.37.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.0.0-alpha.37.tgz",
       "integrity": "sha1-mL69YsTB2flg7DQM+fdSLjBwmiI=",
       "dev": true,
       "dependencies": {
@@ -6179,7 +6179,7 @@
     },
     "node_modules/css-tree/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -6188,7 +6188,7 @@
     },
     "node_modules/css-what": {
       "version": "3.4.2",
-      "resolved": "https://registry.npm.taobao.org/css-what/download/css-what-3.4.2.tgz?cache=0&sync_timestamp=1602570915327&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-3.4.2.tgz",
+      "resolved": "https://registry.npmmirror.com/css-what/download/css-what-3.4.2.tgz?cache=0&sync_timestamp=1602570915327&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-3.4.2.tgz",
       "integrity": "sha1-6nAm/LAXd+295SEk4h8yfnrpUOQ=",
       "dev": true,
       "engines": {
@@ -6197,7 +6197,7 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssesc/download/cssesc-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cssesc/download/cssesc-3.0.0.tgz",
       "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "dev": true,
       "bin": {
@@ -6209,7 +6209,7 @@
     },
     "node_modules/cssnano": {
       "version": "4.1.10",
-      "resolved": "https://registry.npm.taobao.org/cssnano/download/cssnano-4.1.10.tgz?cache=0&sync_timestamp=1612632668700&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano%2Fdownload%2Fcssnano-4.1.10.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano/download/cssnano-4.1.10.tgz?cache=0&sync_timestamp=1612632668700&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano%2Fdownload%2Fcssnano-4.1.10.tgz",
       "integrity": "sha1-CsQfCxPRPUZUh+ERt3jULaYxuLI=",
       "dev": true,
       "dependencies": {
@@ -6224,7 +6224,7 @@
     },
     "node_modules/cssnano-preset-default": {
       "version": "4.0.7",
-      "resolved": "https://registry.npm.taobao.org/cssnano-preset-default/download/cssnano-preset-default-4.0.7.tgz?cache=0&sync_timestamp=1612632637438&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano-preset-default%2Fdownload%2Fcssnano-preset-default-4.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-preset-default/download/cssnano-preset-default-4.0.7.tgz?cache=0&sync_timestamp=1612632637438&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano-preset-default%2Fdownload%2Fcssnano-preset-default-4.0.7.tgz",
       "integrity": "sha1-UexmLM/KD4izltzZZ5zbkxvhf3Y=",
       "dev": true,
       "dependencies": {
@@ -6265,7 +6265,7 @@
     },
     "node_modules/cssnano-util-get-arguments": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
       "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
       "dev": true,
       "engines": {
@@ -6274,7 +6274,7 @@
     },
     "node_modules/cssnano-util-get-match": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
       "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
       "dev": true,
       "engines": {
@@ -6283,7 +6283,7 @@
     },
     "node_modules/cssnano-util-raw-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-raw-cache/download/cssnano-util-raw-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-raw-cache/download/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
       "dev": true,
       "dependencies": {
@@ -6295,7 +6295,7 @@
     },
     "node_modules/cssnano-util-same-parent": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-same-parent/download/cssnano-util-same-parent-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-same-parent/download/cssnano-util-same-parent-4.0.1.tgz",
       "integrity": "sha1-V0CC+yhZ0ttDOFWDXZqEVuoYu/M=",
       "dev": true,
       "engines": {
@@ -6304,7 +6304,7 @@
     },
     "node_modules/csso": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/csso/download/csso-4.2.0.tgz?cache=0&sync_timestamp=1606408849393&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcsso%2Fdownload%2Fcsso-4.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/csso/download/csso-4.2.0.tgz?cache=0&sync_timestamp=1606408849393&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcsso%2Fdownload%2Fcsso-4.2.0.tgz",
       "integrity": "sha1-6jpWE0bo3J9UbW/r7dUBh884lSk=",
       "dev": true,
       "dependencies": {
@@ -6316,7 +6316,7 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/css-tree/download/css-tree-1.1.2.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/css-tree/download/css-tree-1.1.2.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.1.2.tgz",
       "integrity": "sha1-muOTtdr9fa6KYiR1yux409j717U=",
       "dev": true,
       "dependencies": {
@@ -6329,13 +6329,13 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.14",
-      "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.14.tgz",
+      "resolved": "https://registry.npmmirror.com/mdn-data/download/mdn-data-2.0.14.tgz",
       "integrity": "sha1-cRP8QoGRfWPOKbQ0RvcB5owlulA=",
       "dev": true
     },
     "node_modules/csso/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -6455,7 +6455,7 @@
     },
     "node_modules/default-gateway": {
       "version": "5.0.5",
-      "resolved": "https://registry.npm.taobao.org/default-gateway/download/default-gateway-5.0.5.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-5.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/default-gateway/download/default-gateway-5.0.5.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-5.0.5.tgz",
       "integrity": "sha1-T9a9XShV05s0zFpZUFSG6ar8mxA=",
       "dev": true,
       "dependencies": {
@@ -6467,7 +6467,7 @@
     },
     "node_modules/default-gateway/node_modules/execa": {
       "version": "3.4.0",
-      "resolved": "https://registry.npm.taobao.org/execa/download/execa-3.4.0.tgz?cache=0&sync_timestamp=1606971018065&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-3.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/execa/download/execa-3.4.0.tgz?cache=0&sync_timestamp=1606971018065&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-3.4.0.tgz",
       "integrity": "sha1-wI7UVQ72XYWPrCaf/IVyRG8364k=",
       "dev": true,
       "dependencies": {
@@ -6488,7 +6488,7 @@
     },
     "node_modules/default-gateway/node_modules/is-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-stream/download/is-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-stream/download/is-stream-2.0.0.tgz",
       "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM=",
       "dev": true,
       "engines": {
@@ -6497,7 +6497,7 @@
     },
     "node_modules/default-gateway/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/mimic-fn/download/mimic-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mimic-fn/download/mimic-fn-2.1.0.tgz",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true,
       "engines": {
@@ -6506,7 +6506,7 @@
     },
     "node_modules/default-gateway/node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/npm-run-path/download/npm-run-path-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/npm-run-path/download/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
       "dependencies": {
@@ -6518,7 +6518,7 @@
     },
     "node_modules/default-gateway/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npm.taobao.org/onetime/download/onetime-5.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/onetime/download/onetime-5.1.2.tgz",
       "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "dev": true,
       "dependencies": {
@@ -6530,7 +6530,7 @@
     },
     "node_modules/default-gateway/node_modules/p-finally": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/p-finally/download/p-finally-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/p-finally/download/p-finally-2.0.1.tgz",
       "integrity": "sha1-vW/KqcVZoJa2gIBvTWV7Pw8kBWE=",
       "dev": true,
       "engines": {
@@ -6672,7 +6672,7 @@
     },
     "node_modules/del": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/del/download/del-4.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/del/download/del-4.1.1.tgz",
       "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
       "dev": true,
       "dependencies": {
@@ -6690,7 +6690,7 @@
     },
     "node_modules/del/node_modules/globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npm.taobao.org/globby/download/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/globby/download/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "dependencies": {
@@ -6706,7 +6706,7 @@
     },
     "node_modules/del/node_modules/globby/node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz?cache=0&sync_timestamp=1593529716831&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpify%2Fdownload%2Fpify-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/pify/download/pify-2.3.0.tgz?cache=0&sync_timestamp=1593529716831&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpify%2Fdownload%2Fpify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true,
       "engines": {
@@ -6715,7 +6715,7 @@
     },
     "node_modules/del/node_modules/p-map": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/p-map/download/p-map-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/p-map/download/p-map-2.1.0.tgz",
       "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
       "dev": true,
       "engines": {
@@ -6761,7 +6761,7 @@
     },
     "node_modules/detect-node": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/detect-node/download/detect-node-2.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/detect-node/download/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
       "dev": true
     },
@@ -6805,7 +6805,7 @@
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/dns-equal/download/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dns-equal/download/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
@@ -6821,7 +6821,7 @@
     },
     "node_modules/dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/dns-txt/download/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/dns-txt/download/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "dependencies": {
@@ -6830,7 +6830,7 @@
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/dom-converter/download/dom-converter-0.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dom-converter/download/dom-converter-0.2.0.tgz",
       "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
       "dev": true,
       "dependencies": {
@@ -6839,7 +6839,7 @@
     },
     "node_modules/dom-serializer": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.2.2.tgz?cache=0&sync_timestamp=1607193380961&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdom-serializer%2Fdownload%2Fdom-serializer-0.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/dom-serializer/download/dom-serializer-0.2.2.tgz?cache=0&sync_timestamp=1607193380961&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdom-serializer%2Fdownload%2Fdom-serializer-0.2.2.tgz",
       "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
       "dev": true,
       "dependencies": {
@@ -6849,7 +6849,7 @@
     },
     "node_modules/dom-serializer/node_modules/domelementtype": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-2.1.0.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/domelementtype/download/domelementtype-2.1.0.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-2.1.0.tgz",
       "integrity": "sha1-qFHAgKbRw9lDRK7RUdmfZp7fWF4=",
       "dev": true
     },
@@ -6865,7 +6865,7 @@
     },
     "node_modules/domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-1.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/domelementtype/download/domelementtype-1.3.1.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-1.3.1.tgz",
       "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
       "dev": true
     },
@@ -6898,7 +6898,7 @@
     },
     "node_modules/domutils": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz?cache=0&sync_timestamp=1607393056952&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomutils%2Fdownload%2Fdomutils-1.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/domutils/download/domutils-1.7.0.tgz?cache=0&sync_timestamp=1607393056952&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomutils%2Fdownload%2Fdomutils-1.7.0.tgz",
       "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
       "dev": true,
       "dependencies": {
@@ -6943,7 +6943,7 @@
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npm.taobao.org/dot-prop/download/dot-prop-5.3.0.tgz?cache=0&sync_timestamp=1605778245785&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdot-prop%2Fdownload%2Fdot-prop-5.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dot-prop/download/dot-prop-5.3.0.tgz?cache=0&sync_timestamp=1605778245785&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdot-prop%2Fdownload%2Fdot-prop-5.3.0.tgz",
       "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
       "dev": true,
       "dependencies": {
@@ -6955,7 +6955,7 @@
     },
     "node_modules/dot-prop/node_modules/is-obj": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-obj/download/is-obj-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-obj/download/is-obj-2.0.0.tgz",
       "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI=",
       "dev": true,
       "engines": {
@@ -6964,7 +6964,7 @@
     },
     "node_modules/dotenv": {
       "version": "8.2.0",
-      "resolved": "https://registry.npm.taobao.org/dotenv/download/dotenv-8.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dotenv/download/dotenv-8.2.0.tgz",
       "integrity": "sha1-l+YZJZradQ7qPk6j4mvO6lQksWo=",
       "dev": true,
       "engines": {
@@ -6973,13 +6973,13 @@
     },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
-      "resolved": "https://registry.npm.taobao.org/dotenv-expand/download/dotenv-expand-5.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dotenv-expand/download/dotenv-expand-5.1.0.tgz",
       "integrity": "sha1-P7rwIL/XlIhAcuomsel5HUWmKfA=",
       "dev": true
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/duplexer/download/duplexer-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/duplexer/download/duplexer-0.1.2.tgz",
       "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY=",
       "dev": true
     },
@@ -7079,7 +7079,7 @@
     },
     "node_modules/ejs": {
       "version": "2.7.4",
-      "resolved": "https://registry.npm.taobao.org/ejs/download/ejs-2.7.4.tgz",
+      "resolved": "https://registry.npmmirror.com/ejs/download/ejs-2.7.4.tgz",
       "integrity": "sha1-SGYSh1c9zFPjZsehrlLDoSDuybo=",
       "dev": true,
       "engines": {
@@ -7298,7 +7298,7 @@
     },
     "node_modules/entities": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/entities/download/entities-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/entities/download/entities-2.2.0.tgz",
       "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU=",
       "dev": true
     },
@@ -7324,7 +7324,7 @@
     },
     "node_modules/error-stack-parser": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/error-stack-parser/download/error-stack-parser-2.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/error-stack-parser/download/error-stack-parser-2.0.6.tgz",
       "integrity": "sha1-WpmnB716TFinl5AtSNgoA+3mqtg=",
       "dev": true,
       "dependencies": {
@@ -7382,7 +7382,7 @@
     },
     "node_modules/escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npm.taobao.org/escalade/download/escalade-3.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/escalade/download/escalade-3.1.1.tgz",
       "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
       "dev": true,
       "engines": {
@@ -7476,7 +7476,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npm.taobao.org/etag/download/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmmirror.com/etag/download/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true,
       "engines": {
@@ -7494,7 +7494,7 @@
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npm.taobao.org/eventemitter3/download/eventemitter3-4.0.7.tgz?cache=0&sync_timestamp=1598517819668&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feventemitter3%2Fdownload%2Feventemitter3-4.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/eventemitter3/download/eventemitter3-4.0.7.tgz?cache=0&sync_timestamp=1598517819668&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feventemitter3%2Fdownload%2Feventemitter3-4.0.7.tgz",
       "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
       "dev": true
     },
@@ -7509,7 +7509,7 @@
     },
     "node_modules/eventsource": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/eventsource/download/eventsource-1.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/eventsource/download/eventsource-1.0.7.tgz",
       "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
       "dev": true,
       "dependencies": {
@@ -7676,7 +7676,7 @@
     },
     "node_modules/express": {
       "version": "4.17.1",
-      "resolved": "https://registry.npm.taobao.org/express/download/express-4.17.1.tgz?cache=0&sync_timestamp=1596722127254&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexpress%2Fdownload%2Fexpress-4.17.1.tgz",
+      "resolved": "https://registry.npmmirror.com/express/download/express-4.17.1.tgz?cache=0&sync_timestamp=1596722127254&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexpress%2Fdownload%2Fexpress-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "dev": true,
       "dependencies": {
@@ -7717,7 +7717,7 @@
     },
     "node_modules/express/node_modules/cookie": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/cookie/download/cookie-0.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cookie/download/cookie-0.4.0.tgz",
       "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
       "dev": true,
       "engines": {
@@ -7726,7 +7726,7 @@
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -7735,19 +7735,19 @@
     },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/express/node_modules/path-to-regexp": {
       "version": "0.1.7",
-      "resolved": "https://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath-to-regexp%2Fdownload%2Fpath-to-regexp-0.1.7.tgz",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/download/path-to-regexp-0.1.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath-to-regexp%2Fdownload%2Fpath-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "node_modules/express/node_modules/qs": {
       "version": "6.7.0",
-      "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
       "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
       "dev": true,
       "engines": {
@@ -7756,7 +7756,7 @@
     },
     "node_modules/express/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
@@ -7934,7 +7934,7 @@
     },
     "node_modules/faye-websocket": {
       "version": "0.11.3",
-      "resolved": "https://registry.npm.taobao.org/faye-websocket/download/faye-websocket-0.11.3.tgz",
+      "resolved": "https://registry.npmmirror.com/faye-websocket/download/faye-websocket-0.11.3.tgz",
       "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
       "dev": true,
       "dependencies": {
@@ -7952,7 +7952,7 @@
     },
     "node_modules/file-loader": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/file-loader/download/file-loader-4.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/file-loader/download/file-loader-4.3.0.tgz",
       "integrity": "sha1-eA8ED3KbPRgBnyBgX3I+hEuKWK8=",
       "dev": true,
       "dependencies": {
@@ -7975,7 +7975,7 @@
     },
     "node_modules/filesize": {
       "version": "3.6.1",
-      "resolved": "https://registry.npm.taobao.org/filesize/download/filesize-3.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/filesize/download/filesize-3.6.1.tgz",
       "integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc=",
       "dev": true,
       "engines": {
@@ -8011,7 +8011,7 @@
     },
     "node_modules/finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/finalhandler/download/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/finalhandler/download/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "dev": true,
       "dependencies": {
@@ -8029,7 +8029,7 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -8038,7 +8038,7 @@
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
@@ -8119,7 +8119,7 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.13.2",
-      "resolved": "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.13.2.tgz?cache=0&sync_timestamp=1611606737937&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffollow-redirects%2Fdownload%2Ffollow-redirects-1.13.2.tgz",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/download/follow-redirects-1.13.2.tgz?cache=0&sync_timestamp=1611606737937&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffollow-redirects%2Fdownload%2Ffollow-redirects-1.13.2.tgz",
       "integrity": "sha1-3XPI7/wScoulz0JZ12DqX7g+MUc=",
       "dev": true,
       "engines": {
@@ -8208,7 +8208,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/forwarded/download/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/forwarded/download/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true,
       "engines": {
@@ -8524,7 +8524,7 @@
     },
     "node_modules/gzip-size": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/gzip-size/download/gzip-size-5.1.1.tgz?cache=0&sync_timestamp=1605523125680&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgzip-size%2Fdownload%2Fgzip-size-5.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/gzip-size/download/gzip-size-5.1.1.tgz?cache=0&sync_timestamp=1605523125680&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgzip-size%2Fdownload%2Fgzip-size-5.1.1.tgz",
       "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
       "dev": true,
       "dependencies": {
@@ -8537,7 +8537,7 @@
     },
     "node_modules/handle-thing": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/handle-thing/download/handle-thing-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/handle-thing/download/handle-thing-2.0.1.tgz",
       "integrity": "sha1-hX95zjWVgMNA1DCBzGSJcNC7I04=",
       "dev": true
     },
@@ -8672,7 +8672,7 @@
     },
     "node_modules/hash-sum": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-2.0.0.tgz",
       "integrity": "sha1-gdAbtd6OpKIUrV1urRtSNGCwtFo=",
       "dev": true
     },
@@ -8714,13 +8714,13 @@
     },
     "node_modules/hex-color-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/hex-color-regex/download/hex-color-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hex-color-regex/download/hex-color-regex-1.1.0.tgz",
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=",
       "dev": true
     },
     "node_modules/highlight.js": {
       "version": "10.6.0",
-      "resolved": "https://registry.npm.taobao.org/highlight.js/download/highlight.js-10.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/highlight.js/download/highlight.js-10.6.0.tgz",
       "integrity": "sha1-AHOqcdVmkGllum4be+eyaC9eGLY=",
       "dev": true,
       "engines": {
@@ -8740,7 +8740,7 @@
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/hoopy/download/hoopy-0.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/hoopy/download/hoopy-0.1.4.tgz",
       "integrity": "sha1-YJIH1mEQADOpqUAq096mdzgcGx0=",
       "dev": true,
       "engines": {
@@ -8755,7 +8755,7 @@
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npm.taobao.org/hpack.js/download/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmmirror.com/hpack.js/download/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "dependencies": {
@@ -8767,13 +8767,13 @@
     },
     "node_modules/hpack.js/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/isarray/download/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "node_modules/hpack.js/node_modules/readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz",
+      "resolved": "https://registry.npmmirror.com/readable-stream/download/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "dependencies": {
@@ -8788,7 +8788,7 @@
     },
     "node_modules/hpack.js/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/string_decoder/download/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "dependencies": {
@@ -8797,25 +8797,25 @@
     },
     "node_modules/hsl-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsl-regex/download/hsl-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hsl-regex/download/hsl-regex-1.0.0.tgz",
       "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
       "dev": true
     },
     "node_modules/hsla-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsla-regex/download/hsla-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hsla-regex/download/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
     },
     "node_modules/html-comment-regex": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
       "integrity": "sha1-l9RoiutcgYhqNk+qDK0d2hTUM6c=",
       "dev": true
     },
     "node_modules/html-entities": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/html-entities/download/html-entities-1.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-entities%2Fdownload%2Fhtml-entities-1.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/html-entities/download/html-entities-1.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-entities%2Fdownload%2Fhtml-entities-1.4.0.tgz",
       "integrity": "sha1-z70bAdKvr5rcobEK59/6uYxx0tw=",
       "dev": true
     },
@@ -8827,7 +8827,7 @@
     },
     "node_modules/html-minifier": {
       "version": "3.5.21",
-      "resolved": "https://registry.npm.taobao.org/html-minifier/download/html-minifier-3.5.21.tgz",
+      "resolved": "https://registry.npmmirror.com/html-minifier/download/html-minifier-3.5.21.tgz",
       "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
       "dev": true,
       "dependencies": {
@@ -8904,7 +8904,7 @@
     },
     "node_modules/html-minifier/node_modules/commander": {
       "version": "2.17.1",
-      "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.17.1.tgz",
+      "resolved": "https://registry.npmmirror.com/commander/download/commander-2.17.1.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.17.1.tgz",
       "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
       "dev": true
     },
@@ -8919,7 +8919,7 @@
     },
     "node_modules/html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/html-webpack-plugin/download/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/html-webpack-plugin/download/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "dependencies": {
@@ -8940,7 +8940,7 @@
     },
     "node_modules/html-webpack-plugin/node_modules/big.js": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/big.js/download/big.js-3.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/big.js/download/big.js-3.2.0.tgz",
       "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
       "dev": true,
       "engines": {
@@ -8949,7 +8949,7 @@
     },
     "node_modules/html-webpack-plugin/node_modules/emojis-list": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/emojis-list/download/emojis-list-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/emojis-list/download/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true,
       "engines": {
@@ -8958,7 +8958,7 @@
     },
     "node_modules/html-webpack-plugin/node_modules/json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz?cache=0&sync_timestamp=1612146079519&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-0.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/json5/download/json5-0.5.1.tgz?cache=0&sync_timestamp=1612146079519&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true,
       "bin": {
@@ -8967,7 +8967,7 @@
     },
     "node_modules/html-webpack-plugin/node_modules/loader-utils": {
       "version": "0.2.17",
-      "resolved": "https://registry.npm.taobao.org/loader-utils/download/loader-utils-0.2.17.tgz",
+      "resolved": "https://registry.npmmirror.com/loader-utils/download/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
       "dev": true,
       "dependencies": {
@@ -9075,7 +9075,7 @@
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npm.taobao.org/http-deceiver/download/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/http-deceiver/download/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
@@ -9096,13 +9096,13 @@
     },
     "node_modules/http-parser-js": {
       "version": "0.5.3",
-      "resolved": "https://registry.npm.taobao.org/http-parser-js/download/http-parser-js-0.5.3.tgz?cache=0&sync_timestamp=1609542336109&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-parser-js%2Fdownload%2Fhttp-parser-js-0.5.3.tgz",
+      "resolved": "https://registry.npmmirror.com/http-parser-js/download/http-parser-js-0.5.3.tgz?cache=0&sync_timestamp=1609542336109&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-parser-js%2Fdownload%2Fhttp-parser-js-0.5.3.tgz",
       "integrity": "sha1-AdJwnHnUFpi7AdTezF6dpOSgM9k=",
       "dev": true
     },
     "node_modules/http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy/download/http-proxy-1.18.1.tgz",
+      "resolved": "https://registry.npmmirror.com/http-proxy/download/http-proxy-1.18.1.tgz",
       "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
       "dev": true,
       "dependencies": {
@@ -9116,7 +9116,7 @@
     },
     "node_modules/http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz?cache=0&sync_timestamp=1602445480546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-proxy-middleware%2Fdownload%2Fhttp-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npmmirror.com/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz?cache=0&sync_timestamp=1602445480546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-proxy-middleware%2Fdownload%2Fhttp-proxy-middleware-0.19.1.tgz",
       "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
       "dev": true,
       "dependencies": {
@@ -9152,7 +9152,7 @@
     },
     "node_modules/human-signals": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/human-signals/download/human-signals-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/human-signals/download/human-signals-1.1.1.tgz",
       "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
       "dev": true,
       "engines": {
@@ -9173,7 +9173,7 @@
     },
     "node_modules/icss-utils": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/icss-utils/download/icss-utils-4.1.1.tgz?cache=0&sync_timestamp=1605801375650&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ficss-utils%2Fdownload%2Ficss-utils-4.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/icss-utils/download/icss-utils-4.1.1.tgz?cache=0&sync_timestamp=1605801375650&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ficss-utils%2Fdownload%2Ficss-utils-4.1.1.tgz",
       "integrity": "sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=",
       "dev": true,
       "dependencies": {
@@ -9224,7 +9224,7 @@
     },
     "node_modules/import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/import-cwd/download/import-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-cwd/download/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "dependencies": {
@@ -9236,7 +9236,7 @@
     },
     "node_modules/import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-2.0.0.tgz?cache=0&sync_timestamp=1608469472392&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-fresh/download/import-fresh-2.0.0.tgz?cache=0&sync_timestamp=1608469472392&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "dependencies": {
@@ -9249,7 +9249,7 @@
     },
     "node_modules/import-from": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/import-from/download/import-from-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-from/download/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "dependencies": {
@@ -9261,7 +9261,7 @@
     },
     "node_modules/import-local": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-local/download/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-local/download/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "dependencies": {
@@ -9286,7 +9286,7 @@
     },
     "node_modules/indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/indexes-of/download/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/indexes-of/download/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
@@ -9318,7 +9318,7 @@
     },
     "node_modules/internal-ip": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/internal-ip/download/internal-ip-4.3.0.tgz?cache=0&sync_timestamp=1605885556992&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finternal-ip%2Fdownload%2Finternal-ip-4.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/internal-ip/download/internal-ip-4.3.0.tgz?cache=0&sync_timestamp=1605885556992&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finternal-ip%2Fdownload%2Finternal-ip-4.3.0.tgz",
       "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
       "dev": true,
       "dependencies": {
@@ -9331,7 +9331,7 @@
     },
     "node_modules/internal-ip/node_modules/default-gateway": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/default-gateway/download/default-gateway-4.2.0.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-4.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/default-gateway/download/default-gateway-4.2.0.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-4.2.0.tgz",
       "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
       "dev": true,
       "dependencies": {
@@ -9353,13 +9353,13 @@
     },
     "node_modules/ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmmirror.com/ip/download/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "node_modules/ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/ip-regex/download/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ip-regex/download/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true,
       "engines": {
@@ -9368,7 +9368,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/ipaddr.js/download/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/download/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "dev": true,
       "engines": {
@@ -9377,7 +9377,7 @@
     },
     "node_modules/is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true,
       "engines": {
@@ -9443,7 +9443,7 @@
     },
     "node_modules/is-color-stop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-color-stop/download/is-color-stop-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-color-stop/download/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "dependencies": {
@@ -9525,7 +9525,7 @@
     },
     "node_modules/is-directory": {
       "version": "0.3.1",
-      "resolved": "https://registry.npm.taobao.org/is-directory/download/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/is-directory/download/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true,
       "engines": {
@@ -9534,7 +9534,7 @@
     },
     "node_modules/is-docker": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/is-docker/download/is-docker-2.1.1.tgz?cache=0&sync_timestamp=1596559460885&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-docker%2Fdownload%2Fis-docker-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/is-docker/download/is-docker-2.1.1.tgz?cache=0&sync_timestamp=1596559460885&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-docker%2Fdownload%2Fis-docker-2.1.1.tgz",
       "integrity": "sha1-QSWojkTkUNOE4JBH7eca3C0UQVY=",
       "dev": true,
       "bin": {
@@ -9650,7 +9650,7 @@
     },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
       "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true,
       "engines": {
@@ -9659,7 +9659,7 @@
     },
     "node_modules/is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-in-cwd/download/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-path-in-cwd/download/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
       "dev": true,
       "dependencies": {
@@ -9671,7 +9671,7 @@
     },
     "node_modules/is-path-inside": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-inside/download/is-path-inside-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-path-inside/download/is-path-inside-2.1.0.tgz",
       "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
       "dev": true,
       "dependencies": {
@@ -9683,7 +9683,7 @@
     },
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true,
       "engines": {
@@ -9725,7 +9725,7 @@
     },
     "node_modules/is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-resolvable/download/is-resolvable-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-resolvable/download/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
@@ -9740,7 +9740,7 @@
     },
     "node_modules/is-svg": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-svg/download/is-svg-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-svg/download/is-svg-3.0.0.tgz",
       "integrity": "sha1-kyHb0pwhLlypnE+peUxxS8r6L3U=",
       "dev": true,
       "dependencies": {
@@ -9937,7 +9937,7 @@
     },
     "node_modules/javascript-stringify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/javascript-stringify/download/javascript-stringify-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/javascript-stringify/download/javascript-stringify-2.0.1.tgz",
       "integrity": "sha1-bvNYA1MQ411mfGde1j0+t8GqGeU=",
       "dev": true
     },
@@ -10064,7 +10064,7 @@
     },
     "node_modules/json3": {
       "version": "3.3.3",
-      "resolved": "https://registry.npm.taobao.org/json3/download/json3-3.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/json3/download/json3-3.3.3.tgz",
       "integrity": "sha1-f8EON1/FrkLEcFpcwKpvYr4wW4E=",
       "dev": true
     },
@@ -10128,7 +10128,7 @@
     },
     "node_modules/killable": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/killable/download/killable-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/killable/download/killable-1.0.1.tgz",
       "integrity": "sha1-TIzkQRh6Bhx0dPuHygjipjgZSJI=",
       "dev": true
     },
@@ -10232,7 +10232,7 @@
     },
     "node_modules/launch-editor-middleware": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/launch-editor-middleware/download/launch-editor-middleware-2.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/launch-editor-middleware/download/launch-editor-middleware-2.2.1.tgz",
       "integrity": "sha1-4UsH5scVSwpLhqD9NFeE5FgEwVc=",
       "dev": true,
       "dependencies": {
@@ -10512,13 +10512,13 @@
     },
     "node_modules/lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
@@ -10530,13 +10530,13 @@
     },
     "node_modules/lodash.transform": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.transform/download/lodash.transform-4.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.transform/download/lodash.transform-4.6.0.tgz",
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
@@ -10563,7 +10563,7 @@
     },
     "node_modules/loglevel": {
       "version": "1.7.1",
-      "resolved": "https://registry.npm.taobao.org/loglevel/download/loglevel-1.7.1.tgz?cache=0&sync_timestamp=1606314029553&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floglevel%2Fdownload%2Floglevel-1.7.1.tgz",
+      "resolved": "https://registry.npmmirror.com/loglevel/download/loglevel-1.7.1.tgz?cache=0&sync_timestamp=1606314029553&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floglevel%2Fdownload%2Floglevel-1.7.1.tgz",
       "integrity": "sha1-AF/eL15uRwaPk1/yhXPhJe9y8Zc=",
       "dev": true,
       "engines": {
@@ -10593,7 +10593,7 @@
     },
     "node_modules/lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.taobao.org/lower-case/download/lower-case-1.1.4.tgz?cache=0&sync_timestamp=1606867292121&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flower-case%2Fdownload%2Flower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/lower-case/download/lower-case-1.1.4.tgz?cache=0&sync_timestamp=1606867292121&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flower-case%2Fdownload%2Flower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
@@ -10702,7 +10702,7 @@
     },
     "node_modules/mdn-data": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/mdn-data/download/mdn-data-2.0.4.tgz",
       "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs=",
       "dev": true
     },
@@ -10756,7 +10756,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
@@ -10780,7 +10780,7 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/merge-stream/download/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/merge-stream/download/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
@@ -10846,7 +10846,7 @@
     },
     "node_modules/mime": {
       "version": "2.5.0",
-      "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.5.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mime/download/mime-2.5.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.5.0.tgz",
       "integrity": "sha1-K0r5NEAXeYBu6YAmu0Lowa4YdrE=",
       "dev": true,
       "bin": {
@@ -10894,7 +10894,7 @@
     },
     "node_modules/mini-css-extract-plugin": {
       "version": "0.9.0",
-      "resolved": "https://registry.npm.taobao.org/mini-css-extract-plugin/download/mini-css-extract-plugin-0.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mini-css-extract-plugin/download/mini-css-extract-plugin-0.9.0.tgz",
       "integrity": "sha1-R/LPB6oWWrNXM7H8l9TEbAVkM54=",
       "dev": true,
       "dependencies": {
@@ -10912,7 +10912,7 @@
     },
     "node_modules/mini-css-extract-plugin/node_modules/normalize-url": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/normalize-url/download/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
       "dependencies": {
@@ -10927,7 +10927,7 @@
     },
     "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
       "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "dependencies": {
@@ -10983,7 +10983,7 @@
     },
     "node_modules/minipass/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/yallist/download/yallist-4.0.0.tgz",
       "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
       "dev": true
     },
@@ -11485,7 +11485,7 @@
     },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns/download/multicast-dns-6.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/multicast-dns/download/multicast-dns-6.2.3.tgz",
       "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
       "dev": true,
       "dependencies": {
@@ -11498,13 +11498,13 @@
     },
     "node_modules/multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npm.taobao.org/mz/download/mz-2.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mz/download/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "dev": true,
       "dependencies": {
@@ -11587,7 +11587,7 @@
     },
     "node_modules/no-case": {
       "version": "2.3.2",
-      "resolved": "https://registry.npm.taobao.org/no-case/download/no-case-2.3.2.tgz?cache=0&sync_timestamp=1606867290260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fno-case%2Fdownload%2Fno-case-2.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/no-case/download/no-case-2.3.2.tgz?cache=0&sync_timestamp=1606867290260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fno-case%2Fdownload%2Fno-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "dependencies": {
@@ -11638,7 +11638,7 @@
     },
     "node_modules/node-forge": {
       "version": "0.10.0",
-      "resolved": "https://registry.npm.taobao.org/node-forge/download/node-forge-0.10.0.tgz?cache=0&sync_timestamp=1599010719234&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnode-forge%2Fdownload%2Fnode-forge-0.10.0.tgz",
+      "resolved": "https://registry.npmmirror.com/node-forge/download/node-forge-0.10.0.tgz?cache=0&sync_timestamp=1599010719234&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnode-forge%2Fdownload%2Fnode-forge-0.10.0.tgz",
       "integrity": "sha1-Mt6ir7Ppkm8C7lzoeUkCaRpna/M=",
       "dev": true,
       "engines": {
@@ -11766,7 +11766,7 @@
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/normalize-range/download/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true,
       "engines": {
@@ -11809,7 +11809,7 @@
     },
     "node_modules/nth-check": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/nth-check/download/nth-check-1.0.2.tgz?cache=0&sync_timestamp=1606860664533&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnth-check%2Fdownload%2Fnth-check-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/nth-check/download/nth-check-1.0.2.tgz?cache=0&sync_timestamp=1606860664533&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnth-check%2Fdownload%2Fnth-check-1.0.2.tgz",
       "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
       "dev": true,
       "dependencies": {
@@ -11818,7 +11818,7 @@
     },
     "node_modules/num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://registry.npm.taobao.org/num2fraction/download/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/num2fraction/download/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
@@ -12058,7 +12058,7 @@
     },
     "node_modules/obuf": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/obuf/download/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/obuf/download/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
       "dev": true
     },
@@ -12075,7 +12075,7 @@
     },
     "node_modules/on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/on-headers/download/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/on-headers/download/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
       "dev": true,
       "engines": {
@@ -12121,7 +12121,7 @@
     },
     "node_modules/opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/opener/download/opener-1.5.2.tgz",
+      "resolved": "https://registry.npmmirror.com/opener/download/opener-1.5.2.tgz",
       "integrity": "sha1-XTfh81B3udysQwE3InGv3rKhNZg=",
       "dev": true,
       "bin": {
@@ -12130,7 +12130,7 @@
     },
     "node_modules/opn": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/opn/download/opn-5.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/opn/download/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "dev": true,
       "dependencies": {
@@ -12180,7 +12180,7 @@
     },
     "node_modules/original": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/original/download/original-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/original/download/original-1.0.2.tgz",
       "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
       "dev": true,
       "dependencies": {
@@ -12255,7 +12255,7 @@
     },
     "node_modules/p-retry": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/p-retry/download/p-retry-3.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/p-retry/download/p-retry-3.0.1.tgz",
       "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
       "dev": true,
       "dependencies": {
@@ -12349,7 +12349,7 @@
     },
     "node_modules/param-case": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/param-case/download/param-case-2.1.1.tgz?cache=0&sync_timestamp=1606867288643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparam-case%2Fdownload%2Fparam-case-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/param-case/download/param-case-2.1.1.tgz?cache=0&sync_timestamp=1606867288643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparam-case%2Fdownload%2Fparam-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "dependencies": {
@@ -12386,13 +12386,13 @@
     },
     "node_modules/parse5": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-5.1.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-5.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/parse5/download/parse5-5.1.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-5.1.1.tgz",
       "integrity": "sha1-9o5OW6GFKsLK3AD0VV//bCq7YXg=",
       "dev": true
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
-      "resolved": "https://registry.npm.taobao.org/parse5-htmlparser2-tree-adapter/download/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/parse5-htmlparser2-tree-adapter/download/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
       "integrity": "sha1-LN+a2CMyEUA3DU2/XT6Sx8jdxuY=",
       "dev": true,
       "dependencies": {
@@ -12401,7 +12401,7 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
       "version": "6.0.1",
-      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-6.0.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-6.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/parse5/download/parse5-6.0.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-6.0.1.tgz",
       "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
       "dev": true
     },
@@ -12499,7 +12499,7 @@
     },
     "node_modules/path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/path-is-inside/download/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/path-is-inside/download/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
@@ -12634,7 +12634,7 @@
     },
     "node_modules/pnp-webpack-plugin": {
       "version": "1.6.4",
-      "resolved": "https://registry.npm.taobao.org/pnp-webpack-plugin/download/pnp-webpack-plugin-1.6.4.tgz",
+      "resolved": "https://registry.npmmirror.com/pnp-webpack-plugin/download/pnp-webpack-plugin-1.6.4.tgz",
       "integrity": "sha1-yXEaxNxIpoXauvyG+Lbdn434QUk=",
       "dev": true,
       "dependencies": {
@@ -12646,7 +12646,7 @@
     },
     "node_modules/portfinder": {
       "version": "1.0.28",
-      "resolved": "https://registry.npm.taobao.org/portfinder/download/portfinder-1.0.28.tgz",
+      "resolved": "https://registry.npmmirror.com/portfinder/download/portfinder-1.0.28.tgz",
       "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
       "dev": true,
       "dependencies": {
@@ -12660,7 +12660,7 @@
     },
     "node_modules/portfinder/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
       "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
       "dependencies": {
@@ -12696,7 +12696,7 @@
     },
     "node_modules/postcss-calc": {
       "version": "7.0.5",
-      "resolved": "https://registry.npm.taobao.org/postcss-calc/download/postcss-calc-7.0.5.tgz?cache=0&sync_timestamp=1609689190192&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-calc%2Fdownload%2Fpostcss-calc-7.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-calc/download/postcss-calc-7.0.5.tgz?cache=0&sync_timestamp=1609689190192&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-calc%2Fdownload%2Fpostcss-calc-7.0.5.tgz",
       "integrity": "sha1-+KbpnxLmGcLrwjz2xIb9wVhgkz4=",
       "dev": true,
       "dependencies": {
@@ -12707,7 +12707,7 @@
     },
     "node_modules/postcss-colormin": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-colormin/download/postcss-colormin-4.0.3.tgz?cache=0&sync_timestamp=1612632637742&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-colormin%2Fdownload%2Fpostcss-colormin-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-colormin/download/postcss-colormin-4.0.3.tgz?cache=0&sync_timestamp=1612632637742&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-colormin%2Fdownload%2Fpostcss-colormin-4.0.3.tgz",
       "integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
       "dev": true,
       "dependencies": {
@@ -12723,13 +12723,13 @@
     },
     "node_modules/postcss-colormin/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-convert-values": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-convert-values/download/postcss-convert-values-4.0.1.tgz?cache=0&sync_timestamp=1612632638330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-convert-values%2Fdownload%2Fpostcss-convert-values-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-convert-values/download/postcss-convert-values-4.0.1.tgz?cache=0&sync_timestamp=1612632638330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-convert-values%2Fdownload%2Fpostcss-convert-values-4.0.1.tgz",
       "integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
       "dev": true,
       "dependencies": {
@@ -12742,13 +12742,13 @@
     },
     "node_modules/postcss-convert-values/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-discard-comments": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-comments/download/postcss-discard-comments-4.0.2.tgz?cache=0&sync_timestamp=1612632637618&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-comments%2Fdownload%2Fpostcss-discard-comments-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-comments/download/postcss-discard-comments-4.0.2.tgz?cache=0&sync_timestamp=1612632637618&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-comments%2Fdownload%2Fpostcss-discard-comments-4.0.2.tgz",
       "integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
       "dev": true,
       "dependencies": {
@@ -12760,7 +12760,7 @@
     },
     "node_modules/postcss-discard-duplicates": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-duplicates/download/postcss-discard-duplicates-4.0.2.tgz?cache=0&sync_timestamp=1612632637567&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-duplicates%2Fdownload%2Fpostcss-discard-duplicates-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-duplicates/download/postcss-discard-duplicates-4.0.2.tgz?cache=0&sync_timestamp=1612632637567&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-duplicates%2Fdownload%2Fpostcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
       "dev": true,
       "dependencies": {
@@ -12772,7 +12772,7 @@
     },
     "node_modules/postcss-discard-empty": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-empty/download/postcss-discard-empty-4.0.1.tgz?cache=0&sync_timestamp=1612632638357&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-empty%2Fdownload%2Fpostcss-discard-empty-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-empty/download/postcss-discard-empty-4.0.1.tgz?cache=0&sync_timestamp=1612632638357&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-empty%2Fdownload%2Fpostcss-discard-empty-4.0.1.tgz",
       "integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
       "dev": true,
       "dependencies": {
@@ -12784,7 +12784,7 @@
     },
     "node_modules/postcss-discard-overridden": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-overridden/download/postcss-discard-overridden-4.0.1.tgz?cache=0&sync_timestamp=1612632637686&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-overridden%2Fdownload%2Fpostcss-discard-overridden-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-overridden/download/postcss-discard-overridden-4.0.1.tgz?cache=0&sync_timestamp=1612632637686&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-overridden%2Fdownload%2Fpostcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
       "dev": true,
       "dependencies": {
@@ -12796,7 +12796,7 @@
     },
     "node_modules/postcss-load-config": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-load-config/download/postcss-load-config-2.1.2.tgz?cache=0&sync_timestamp=1612743037145&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-load-config%2Fdownload%2Fpostcss-load-config-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-load-config/download/postcss-load-config-2.1.2.tgz?cache=0&sync_timestamp=1612743037145&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-load-config%2Fdownload%2Fpostcss-load-config-2.1.2.tgz",
       "integrity": "sha1-xepQTyxK7zPHNZo03jVzdyrXUCo=",
       "dev": true,
       "dependencies": {
@@ -12809,7 +12809,7 @@
     },
     "node_modules/postcss-loader": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-loader/download/postcss-loader-3.0.0.tgz?cache=0&sync_timestamp=1612277661855&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-loader%2Fdownload%2Fpostcss-loader-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-loader/download/postcss-loader-3.0.0.tgz?cache=0&sync_timestamp=1612277661855&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-loader%2Fdownload%2Fpostcss-loader-3.0.0.tgz",
       "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
       "dev": true,
       "dependencies": {
@@ -12824,7 +12824,7 @@
     },
     "node_modules/postcss-loader/node_modules/schema-utils": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
       "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "dependencies": {
@@ -12838,7 +12838,7 @@
     },
     "node_modules/postcss-merge-longhand": {
       "version": "4.0.11",
-      "resolved": "https://registry.npm.taobao.org/postcss-merge-longhand/download/postcss-merge-longhand-4.0.11.tgz?cache=0&sync_timestamp=1612632638851&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-longhand%2Fdownload%2Fpostcss-merge-longhand-4.0.11.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-merge-longhand/download/postcss-merge-longhand-4.0.11.tgz?cache=0&sync_timestamp=1612632638851&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-longhand%2Fdownload%2Fpostcss-merge-longhand-4.0.11.tgz",
       "integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
       "dev": true,
       "dependencies": {
@@ -12853,13 +12853,13 @@
     },
     "node_modules/postcss-merge-longhand/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-merge-rules": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-merge-rules/download/postcss-merge-rules-4.0.3.tgz?cache=0&sync_timestamp=1612632638899&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-rules%2Fdownload%2Fpostcss-merge-rules-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-merge-rules/download/postcss-merge-rules-4.0.3.tgz?cache=0&sync_timestamp=1612632638899&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-rules%2Fdownload%2Fpostcss-merge-rules-4.0.3.tgz",
       "integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
       "dev": true,
       "dependencies": {
@@ -12876,7 +12876,7 @@
     },
     "node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
       "version": "3.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
       "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
       "dev": true,
       "dependencies": {
@@ -12890,7 +12890,7 @@
     },
     "node_modules/postcss-minify-font-values": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-font-values/download/postcss-minify-font-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640444&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-font-values%2Fdownload%2Fpostcss-minify-font-values-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-font-values/download/postcss-minify-font-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640444&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-font-values%2Fdownload%2Fpostcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
       "dev": true,
       "dependencies": {
@@ -12903,13 +12903,13 @@
     },
     "node_modules/postcss-minify-font-values/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-minify-gradients": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-gradients/download/postcss-minify-gradients-4.0.2.tgz?cache=0&sync_timestamp=1612632640506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-gradients%2Fdownload%2Fpostcss-minify-gradients-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-gradients/download/postcss-minify-gradients-4.0.2.tgz?cache=0&sync_timestamp=1612632640506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-gradients%2Fdownload%2Fpostcss-minify-gradients-4.0.2.tgz",
       "integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
       "dev": true,
       "dependencies": {
@@ -12924,13 +12924,13 @@
     },
     "node_modules/postcss-minify-gradients/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-minify-params": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-params/download/postcss-minify-params-4.0.2.tgz?cache=0&sync_timestamp=1612632640705&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-params%2Fdownload%2Fpostcss-minify-params-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-params/download/postcss-minify-params-4.0.2.tgz?cache=0&sync_timestamp=1612632640705&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-params%2Fdownload%2Fpostcss-minify-params-4.0.2.tgz",
       "integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
       "dev": true,
       "dependencies": {
@@ -12947,13 +12947,13 @@
     },
     "node_modules/postcss-minify-params/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-minify-selectors": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-selectors/download/postcss-minify-selectors-4.0.2.tgz?cache=0&sync_timestamp=1612632640495&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-selectors%2Fdownload%2Fpostcss-minify-selectors-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-selectors/download/postcss-minify-selectors-4.0.2.tgz?cache=0&sync_timestamp=1612632640495&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-selectors%2Fdownload%2Fpostcss-minify-selectors-4.0.2.tgz",
       "integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
       "dev": true,
       "dependencies": {
@@ -12968,7 +12968,7 @@
     },
     "node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
       "version": "3.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
       "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
       "dev": true,
       "dependencies": {
@@ -12982,7 +12982,7 @@
     },
     "node_modules/postcss-modules-extract-imports": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-extract-imports/download/postcss-modules-extract-imports-2.0.0.tgz?cache=0&sync_timestamp=1602588202058&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-extract-imports%2Fdownload%2Fpostcss-modules-extract-imports-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-extract-imports/download/postcss-modules-extract-imports-2.0.0.tgz?cache=0&sync_timestamp=1602588202058&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-extract-imports%2Fdownload%2Fpostcss-modules-extract-imports-2.0.0.tgz",
       "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
       "dev": true,
       "dependencies": {
@@ -12994,7 +12994,7 @@
     },
     "node_modules/postcss-modules-local-by-default": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-local-by-default/download/postcss-modules-local-by-default-3.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-local-by-default/download/postcss-modules-local-by-default-3.0.3.tgz",
       "integrity": "sha1-uxTgzHgnnVBNvcv9fgyiiZP/u7A=",
       "dev": true,
       "dependencies": {
@@ -13009,7 +13009,7 @@
     },
     "node_modules/postcss-modules-scope": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-scope/download/postcss-modules-scope-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-scope/download/postcss-modules-scope-2.2.0.tgz",
       "integrity": "sha1-OFyuATzHdD9afXYC0Qc6iequYu4=",
       "dev": true,
       "dependencies": {
@@ -13022,7 +13022,7 @@
     },
     "node_modules/postcss-modules-values": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-values/download/postcss-modules-values-3.0.0.tgz?cache=0&sync_timestamp=1602586308035&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-values%2Fdownload%2Fpostcss-modules-values-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-values/download/postcss-modules-values-3.0.0.tgz?cache=0&sync_timestamp=1602586308035&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-values%2Fdownload%2Fpostcss-modules-values-3.0.0.tgz",
       "integrity": "sha1-W1AA1uuuKbQlUwG0o6VFdEI+fxA=",
       "dev": true,
       "dependencies": {
@@ -13032,7 +13032,7 @@
     },
     "node_modules/postcss-normalize-charset": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-charset/download/postcss-normalize-charset-4.0.1.tgz?cache=0&sync_timestamp=1612632640617&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-charset%2Fdownload%2Fpostcss-normalize-charset-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-charset/download/postcss-normalize-charset-4.0.1.tgz?cache=0&sync_timestamp=1612632640617&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-charset%2Fdownload%2Fpostcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
       "dev": true,
       "dependencies": {
@@ -13044,7 +13044,7 @@
     },
     "node_modules/postcss-normalize-display-values": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-display-values/download/postcss-normalize-display-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640538&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-display-values%2Fdownload%2Fpostcss-normalize-display-values-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-display-values/download/postcss-normalize-display-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640538&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-display-values%2Fdownload%2Fpostcss-normalize-display-values-4.0.2.tgz",
       "integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
       "dev": true,
       "dependencies": {
@@ -13058,13 +13058,13 @@
     },
     "node_modules/postcss-normalize-display-values/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-positions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-positions/download/postcss-normalize-positions-4.0.2.tgz?cache=0&sync_timestamp=1612632640517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-positions%2Fdownload%2Fpostcss-normalize-positions-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-positions/download/postcss-normalize-positions-4.0.2.tgz?cache=0&sync_timestamp=1612632640517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-positions%2Fdownload%2Fpostcss-normalize-positions-4.0.2.tgz",
       "integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
       "dev": true,
       "dependencies": {
@@ -13079,13 +13079,13 @@
     },
     "node_modules/postcss-normalize-positions/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-repeat-style": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-repeat-style/download/postcss-normalize-repeat-style-4.0.2.tgz?cache=0&sync_timestamp=1612632640701&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-repeat-style%2Fdownload%2Fpostcss-normalize-repeat-style-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-repeat-style/download/postcss-normalize-repeat-style-4.0.2.tgz?cache=0&sync_timestamp=1612632640701&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-repeat-style%2Fdownload%2Fpostcss-normalize-repeat-style-4.0.2.tgz",
       "integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
       "dev": true,
       "dependencies": {
@@ -13100,13 +13100,13 @@
     },
     "node_modules/postcss-normalize-repeat-style/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-string": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-string/download/postcss-normalize-string-4.0.2.tgz?cache=0&sync_timestamp=1612632640644&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-string%2Fdownload%2Fpostcss-normalize-string-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-string/download/postcss-normalize-string-4.0.2.tgz?cache=0&sync_timestamp=1612632640644&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-string%2Fdownload%2Fpostcss-normalize-string-4.0.2.tgz",
       "integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
       "dev": true,
       "dependencies": {
@@ -13120,13 +13120,13 @@
     },
     "node_modules/postcss-normalize-string/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-timing-functions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-timing-functions/download/postcss-normalize-timing-functions-4.0.2.tgz?cache=0&sync_timestamp=1612632641797&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-timing-functions%2Fdownload%2Fpostcss-normalize-timing-functions-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-timing-functions/download/postcss-normalize-timing-functions-4.0.2.tgz?cache=0&sync_timestamp=1612632641797&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-timing-functions%2Fdownload%2Fpostcss-normalize-timing-functions-4.0.2.tgz",
       "integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
       "dev": true,
       "dependencies": {
@@ -13140,13 +13140,13 @@
     },
     "node_modules/postcss-normalize-timing-functions/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-unicode": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-unicode/download/postcss-normalize-unicode-4.0.1.tgz?cache=0&sync_timestamp=1612632641502&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-unicode%2Fdownload%2Fpostcss-normalize-unicode-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-unicode/download/postcss-normalize-unicode-4.0.1.tgz?cache=0&sync_timestamp=1612632641502&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-unicode%2Fdownload%2Fpostcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
       "dev": true,
       "dependencies": {
@@ -13160,13 +13160,13 @@
     },
     "node_modules/postcss-normalize-unicode/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-url": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-url/download/postcss-normalize-url-4.0.1.tgz?cache=0&sync_timestamp=1612632641883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-url%2Fdownload%2Fpostcss-normalize-url-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-url/download/postcss-normalize-url-4.0.1.tgz?cache=0&sync_timestamp=1612632641883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-url%2Fdownload%2Fpostcss-normalize-url-4.0.1.tgz",
       "integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
       "dev": true,
       "dependencies": {
@@ -13181,7 +13181,7 @@
     },
     "node_modules/postcss-normalize-url/node_modules/normalize-url": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-3.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/normalize-url/download/normalize-url-3.3.0.tgz",
       "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
       "dev": true,
       "engines": {
@@ -13190,13 +13190,13 @@
     },
     "node_modules/postcss-normalize-url/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-normalize-whitespace": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-whitespace/download/postcss-normalize-whitespace-4.0.2.tgz?cache=0&sync_timestamp=1612632641822&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-whitespace%2Fdownload%2Fpostcss-normalize-whitespace-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-whitespace/download/postcss-normalize-whitespace-4.0.2.tgz?cache=0&sync_timestamp=1612632641822&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-whitespace%2Fdownload%2Fpostcss-normalize-whitespace-4.0.2.tgz",
       "integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
       "dev": true,
       "dependencies": {
@@ -13209,13 +13209,13 @@
     },
     "node_modules/postcss-normalize-whitespace/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-ordered-values": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-ordered-values/download/postcss-ordered-values-4.1.2.tgz?cache=0&sync_timestamp=1612632651029&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-ordered-values%2Fdownload%2Fpostcss-ordered-values-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-ordered-values/download/postcss-ordered-values-4.1.2.tgz?cache=0&sync_timestamp=1612632651029&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-ordered-values%2Fdownload%2Fpostcss-ordered-values-4.1.2.tgz",
       "integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
       "dev": true,
       "dependencies": {
@@ -13229,13 +13229,13 @@
     },
     "node_modules/postcss-ordered-values/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-reduce-initial": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-reduce-initial/download/postcss-reduce-initial-4.0.3.tgz?cache=0&sync_timestamp=1612632642629&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-initial%2Fdownload%2Fpostcss-reduce-initial-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-reduce-initial/download/postcss-reduce-initial-4.0.3.tgz?cache=0&sync_timestamp=1612632642629&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-initial%2Fdownload%2Fpostcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
       "dev": true,
       "dependencies": {
@@ -13250,7 +13250,7 @@
     },
     "node_modules/postcss-reduce-transforms": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-reduce-transforms/download/postcss-reduce-transforms-4.0.2.tgz?cache=0&sync_timestamp=1612632643250&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-transforms%2Fdownload%2Fpostcss-reduce-transforms-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-reduce-transforms/download/postcss-reduce-transforms-4.0.2.tgz?cache=0&sync_timestamp=1612632643250&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-transforms%2Fdownload%2Fpostcss-reduce-transforms-4.0.2.tgz",
       "integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
       "dev": true,
       "dependencies": {
@@ -13265,13 +13265,13 @@
     },
     "node_modules/postcss-reduce-transforms/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.0.4",
-      "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-6.0.4.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-6.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-6.0.4.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-6.0.4.tgz",
       "integrity": "sha1-VgdaE4CgRgTDiwY+p3Z6Epr1wrM=",
       "dev": true,
       "dependencies": {
@@ -13286,7 +13286,7 @@
     },
     "node_modules/postcss-svgo": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-svgo/download/postcss-svgo-4.0.2.tgz?cache=0&sync_timestamp=1612632644074&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-svgo%2Fdownload%2Fpostcss-svgo-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-svgo/download/postcss-svgo-4.0.2.tgz?cache=0&sync_timestamp=1612632644074&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-svgo%2Fdownload%2Fpostcss-svgo-4.0.2.tgz",
       "integrity": "sha1-F7mXvHEbMzurFDqu07jT1uPTglg=",
       "dev": true,
       "dependencies": {
@@ -13301,13 +13301,13 @@
     },
     "node_modules/postcss-svgo/node_modules/postcss-value-parser": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
       "dev": true
     },
     "node_modules/postcss-unique-selectors": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-unique-selectors/download/postcss-unique-selectors-4.0.1.tgz?cache=0&sync_timestamp=1612632644958&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-unique-selectors%2Fdownload%2Fpostcss-unique-selectors-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-unique-selectors/download/postcss-unique-selectors-4.0.1.tgz?cache=0&sync_timestamp=1612632644958&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-unique-selectors%2Fdownload%2Fpostcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
       "dev": true,
       "dependencies": {
@@ -13321,13 +13321,13 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss=",
       "dev": true
     },
     "node_modules/postcss/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -13336,7 +13336,7 @@
     },
     "node_modules/postcss/node_modules/supports-color": {
       "version": "6.1.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-6.1.0.tgz",
       "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
       "dev": true,
       "dependencies": {
@@ -13348,7 +13348,7 @@
     },
     "node_modules/prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/prepend-http/download/prepend-http-1.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/prepend-http/download/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true,
       "engines": {
@@ -13357,7 +13357,7 @@
     },
     "node_modules/prettier": {
       "version": "1.19.1",
-      "resolved": "https://registry.npm.taobao.org/prettier/download/prettier-1.19.1.tgz",
+      "resolved": "https://registry.npmmirror.com/prettier/download/prettier-1.19.1.tgz",
       "integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
       "dev": true,
       "optional": true,
@@ -13382,7 +13382,7 @@
     },
     "node_modules/pretty-error": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/pretty-error/download/pretty-error-2.1.2.tgz?cache=0&sync_timestamp=1609589422297&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-error%2Fdownload%2Fpretty-error-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/pretty-error/download/pretty-error-2.1.2.tgz?cache=0&sync_timestamp=1609589422297&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-error%2Fdownload%2Fpretty-error-2.1.2.tgz",
       "integrity": "sha1-von4LYGxyG7I/fvDhQRYgnJ/k7Y=",
       "dev": true,
       "dependencies": {
@@ -13428,7 +13428,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/proxy-addr/download/proxy-addr-2.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/download/proxy-addr-2.0.6.tgz",
       "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
       "dev": true,
       "dependencies": {
@@ -13522,7 +13522,7 @@
     },
     "node_modules/q": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/q/download/q-1.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/q/download/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true,
       "engines": {
@@ -13541,7 +13541,7 @@
     },
     "node_modules/query-string": {
       "version": "4.3.4",
-      "resolved": "https://registry.npm.taobao.org/query-string/download/query-string-4.3.4.tgz?cache=0&sync_timestamp=1612938230404&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquery-string%2Fdownload%2Fquery-string-4.3.4.tgz",
+      "resolved": "https://registry.npmmirror.com/query-string/download/query-string-4.3.4.tgz?cache=0&sync_timestamp=1612938230404&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquery-string%2Fdownload%2Fquery-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "dependencies": {
@@ -13572,7 +13572,7 @@
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/querystringify/download/querystringify-2.2.0.tgz?cache=0&sync_timestamp=1597687052330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquerystringify%2Fdownload%2Fquerystringify-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/querystringify/download/querystringify-2.2.0.tgz?cache=0&sync_timestamp=1597687052330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquerystringify%2Fdownload%2Fquerystringify-2.2.0.tgz",
       "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
       "dev": true
     },
@@ -13616,7 +13616,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/range-parser/download/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/range-parser/download/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "dev": true,
       "engines": {
@@ -13639,7 +13639,7 @@
     },
     "node_modules/raw-body": {
       "version": "2.4.0",
-      "resolved": "https://registry.npm.taobao.org/raw-body/download/raw-body-2.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/raw-body/download/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "dev": true,
       "dependencies": {
@@ -13654,7 +13654,7 @@
     },
     "node_modules/raw-body/node_modules/http-errors": {
       "version": "1.7.2",
-      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "dev": true,
       "dependencies": {
@@ -13670,13 +13670,13 @@
     },
     "node_modules/raw-body/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "node_modules/raw-body/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
@@ -13860,7 +13860,7 @@
     },
     "node_modules/relateurl": {
       "version": "0.2.7",
-      "resolved": "https://registry.npm.taobao.org/relateurl/download/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/relateurl/download/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true,
       "engines": {
@@ -14049,7 +14049,7 @@
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/requires-port/download/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
@@ -14077,7 +14077,7 @@
     },
     "node_modules/resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "dependencies": {
@@ -14089,7 +14089,7 @@
     },
     "node_modules/resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/resolve-from/download/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true,
       "engines": {
@@ -14134,7 +14134,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/retry/download/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmmirror.com/retry/download/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true,
       "engines": {
@@ -14143,13 +14143,13 @@
     },
     "node_modules/rgb-regex": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/rgb-regex/download/rgb-regex-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/rgb-regex/download/rgb-regex-1.0.1.tgz",
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
       "dev": true
     },
     "node_modules/rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/rgba-regex/download/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/rgba-regex/download/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },
@@ -14319,7 +14319,7 @@
     },
     "node_modules/sass": {
       "version": "1.32.7",
-      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.32.7.tgz",
+      "resolved": "https://registry.npmmirror.com/sass/download/sass-1.32.7.tgz",
       "integrity": "sha1-Yyqd8rhdxLNGl3/K8tXm8rcDn9g=",
       "dev": true,
       "dependencies": {
@@ -14378,13 +14378,13 @@
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/select-hose/download/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/select-hose/download/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "node_modules/selfsigned": {
       "version": "1.10.8",
-      "resolved": "https://registry.npm.taobao.org/selfsigned/download/selfsigned-1.10.8.tgz?cache=0&sync_timestamp=1600187989135&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fselfsigned%2Fdownload%2Fselfsigned-1.10.8.tgz",
+      "resolved": "https://registry.npmmirror.com/selfsigned/download/selfsigned-1.10.8.tgz?cache=0&sync_timestamp=1600187989135&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fselfsigned%2Fdownload%2Fselfsigned-1.10.8.tgz",
       "integrity": "sha1-DRcgi30Swz+OrIXEGDXyf8PYGjA=",
       "dev": true,
       "dependencies": {
@@ -14402,7 +14402,7 @@
     },
     "node_modules/send": {
       "version": "0.17.1",
-      "resolved": "https://registry.npm.taobao.org/send/download/send-0.17.1.tgz",
+      "resolved": "https://registry.npmmirror.com/send/download/send-0.17.1.tgz",
       "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
       "dev": true,
       "dependencies": {
@@ -14426,7 +14426,7 @@
     },
     "node_modules/send/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -14435,13 +14435,13 @@
     },
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/send/node_modules/http-errors": {
       "version": "1.7.3",
-      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.3.tgz",
+      "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.7.3.tgz",
       "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
       "dev": true,
       "dependencies": {
@@ -14457,7 +14457,7 @@
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true,
       "bin": {
@@ -14469,13 +14469,13 @@
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.1.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.1.1.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.1.tgz",
       "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
       "dev": true
     },
     "node_modules/send/node_modules/setprototypeof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
@@ -14490,7 +14490,7 @@
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/serve-index/download/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/serve-index/download/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "dependencies": {
@@ -14508,7 +14508,7 @@
     },
     "node_modules/serve-index/node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
       "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "dev": true,
       "dependencies": {
@@ -14517,7 +14517,7 @@
     },
     "node_modules/serve-index/node_modules/http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "dependencies": {
@@ -14532,25 +14532,25 @@
     },
     "node_modules/serve-index/node_modules/inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "node_modules/serve-index/node_modules/setprototypeof": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.0.tgz",
       "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
       "dev": true
     },
     "node_modules/serve-static": {
       "version": "1.14.1",
-      "resolved": "https://registry.npm.taobao.org/serve-static/download/serve-static-1.14.1.tgz",
+      "resolved": "https://registry.npmmirror.com/serve-static/download/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "dev": true,
       "dependencies": {
@@ -14991,7 +14991,7 @@
     },
     "node_modules/sockjs": {
       "version": "0.3.21",
-      "resolved": "https://registry.npm.taobao.org/sockjs/download/sockjs-0.3.21.tgz",
+      "resolved": "https://registry.npmmirror.com/sockjs/download/sockjs-0.3.21.tgz",
       "integrity": "sha1-s0/7mOeWkwtgoM+hGQTWozmn1Bc=",
       "dev": true,
       "dependencies": {
@@ -15002,7 +15002,7 @@
     },
     "node_modules/sockjs-client": {
       "version": "1.5.0",
-      "resolved": "https://registry.npm.taobao.org/sockjs-client/download/sockjs-client-1.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/sockjs-client/download/sockjs-client-1.5.0.tgz",
       "integrity": "sha1-L4/11LZZ4NCS96ugt8OGvSqiCt0=",
       "dev": true,
       "dependencies": {
@@ -15016,7 +15016,7 @@
     },
     "node_modules/sockjs-client/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
       "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
       "dev": true,
       "dependencies": {
@@ -15025,7 +15025,7 @@
     },
     "node_modules/sort-keys": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/sort-keys/download/sort-keys-1.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsort-keys%2Fdownload%2Fsort-keys-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/sort-keys/download/sort-keys-1.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsort-keys%2Fdownload%2Fsort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "dependencies": {
@@ -15154,7 +15154,7 @@
     },
     "node_modules/spdy": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/spdy/download/spdy-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/spdy/download/spdy-4.0.2.tgz",
       "integrity": "sha1-t09GYgOj7aRSwCSSuR+56EonZ3s=",
       "dev": true,
       "dependencies": {
@@ -15170,7 +15170,7 @@
     },
     "node_modules/spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/spdy-transport/download/spdy-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/spdy-transport/download/spdy-transport-3.0.0.tgz",
       "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
       "dev": true,
       "dependencies": {
@@ -15231,13 +15231,13 @@
     },
     "node_modules/stable": {
       "version": "0.1.8",
-      "resolved": "https://registry.npm.taobao.org/stable/download/stable-0.1.8.tgz",
+      "resolved": "https://registry.npmmirror.com/stable/download/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
     "node_modules/stackframe": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/stackframe/download/stackframe-1.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/stackframe/download/stackframe-1.2.0.tgz",
       "integrity": "sha1-UkKUktY8YuuYmATBFVLj0i53kwM=",
       "dev": true
     },
@@ -15378,7 +15378,7 @@
     },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true,
       "engines": {
@@ -15551,7 +15551,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-final-newline/download/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-final-newline/download/strip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true,
       "engines": {
@@ -15572,7 +15572,7 @@
     },
     "node_modules/stylehacks": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/stylehacks/download/stylehacks-4.0.3.tgz?cache=0&sync_timestamp=1612632646142&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstylehacks%2Fdownload%2Fstylehacks-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/stylehacks/download/stylehacks-4.0.3.tgz?cache=0&sync_timestamp=1612632646142&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstylehacks%2Fdownload%2Fstylehacks-4.0.3.tgz",
       "integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
       "dev": true,
       "dependencies": {
@@ -15586,7 +15586,7 @@
     },
     "node_modules/stylehacks/node_modules/postcss-selector-parser": {
       "version": "3.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
       "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
       "dev": true,
       "dependencies": {
@@ -15646,7 +15646,7 @@
     },
     "node_modules/svgo": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/svgo/download/svgo-1.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/svgo/download/svgo-1.3.2.tgz",
       "integrity": "sha1-ttxRHAYzRsnkFbgeQ0ARRbltQWc=",
       "dev": true,
       "dependencies": {
@@ -15817,7 +15817,7 @@
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/thenify/download/thenify-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/thenify/download/thenify-3.3.1.tgz",
       "integrity": "sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=",
       "dev": true,
       "dependencies": {
@@ -15826,7 +15826,7 @@
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/thenify-all/download/thenify-all-1.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/thenify-all/download/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "dependencies": {
@@ -15900,7 +15900,7 @@
     },
     "node_modules/thunky": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/thunky/download/thunky-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/thunky/download/thunky-1.1.0.tgz",
       "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
       "dev": true
     },
@@ -15918,7 +15918,7 @@
     },
     "node_modules/timsort": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/timsort/download/timsort-0.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/timsort/download/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
@@ -16012,7 +16012,7 @@
     },
     "node_modules/toposort": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/toposort/download/toposort-1.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/toposort/download/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
@@ -16040,7 +16040,7 @@
     },
     "node_modules/tryer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/tryer/download/tryer-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/tryer/download/tryer-1.0.1.tgz",
       "integrity": "sha1-8shUBoALmw90yfdGW4HqrSQSUvg=",
       "dev": true
     },
@@ -16068,7 +16068,7 @@
     },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/ts-pnp/download/ts-pnp-1.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ts-pnp/download/ts-pnp-1.2.0.tgz",
       "integrity": "sha1-pQCtCEsHmPHDBxrzkeZZEshrypI=",
       "dev": true,
       "engines": {
@@ -16163,7 +16163,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.4.10",
-      "resolved": "https://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.10.tgz?cache=0&sync_timestamp=1613235170039&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuglify-js%2Fdownload%2Fuglify-js-3.4.10.tgz",
+      "resolved": "https://registry.npmmirror.com/uglify-js/download/uglify-js-3.4.10.tgz?cache=0&sync_timestamp=1613235170039&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuglify-js%2Fdownload%2Fuglify-js-3.4.10.tgz",
       "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
       "dev": true,
       "dependencies": {
@@ -16179,13 +16179,13 @@
     },
     "node_modules/uglify-js/node_modules/commander": {
       "version": "2.19.0",
-      "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.19.0.tgz",
+      "resolved": "https://registry.npmmirror.com/commander/download/commander-2.19.0.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.19.0.tgz",
       "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
       "dev": true
     },
     "node_modules/uglify-js/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "engines": {
@@ -16249,13 +16249,13 @@
     },
     "node_modules/uniq": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/uniq/download/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/uniq/download/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "node_modules/uniqs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/uniqs/download/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/uniqs/download/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
@@ -16300,7 +16300,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/unpipe/download/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/unpipe/download/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true,
       "engines": {
@@ -16309,7 +16309,7 @@
     },
     "node_modules/unquote": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/unquote/download/unquote-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/unquote/download/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
       "dev": true
     },
@@ -16379,7 +16379,7 @@
     },
     "node_modules/upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/upper-case/download/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmmirror.com/upper-case/download/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
@@ -16415,7 +16415,7 @@
     },
     "node_modules/url-loader": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/url-loader/download/url-loader-2.3.0.tgz?cache=0&sync_timestamp=1602252665628&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Furl-loader%2Fdownload%2Furl-loader-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/url-loader/download/url-loader-2.3.0.tgz?cache=0&sync_timestamp=1602252665628&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Furl-loader%2Fdownload%2Furl-loader-2.3.0.tgz",
       "integrity": "sha1-4OLvZY8APvuMpBsPP/v3a6uIZYs=",
       "dev": true,
       "dependencies": {
@@ -16472,7 +16472,7 @@
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/util.promisify/download/util.promisify-1.0.0.tgz?cache=0&sync_timestamp=1610159866228&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil.promisify%2Fdownload%2Futil.promisify-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/util.promisify/download/util.promisify-1.0.0.tgz?cache=0&sync_timestamp=1610159866228&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil.promisify%2Fdownload%2Futil.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "dependencies": {
@@ -16488,7 +16488,7 @@
     },
     "node_modules/utila": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/utila/download/utila-0.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/utila/download/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
@@ -16499,7 +16499,7 @@
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/utils-merge/download/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/utils-merge/download/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true,
       "engines": {
@@ -16558,7 +16558,7 @@
     },
     "node_modules/vendors": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/vendors/download/vendors-1.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/vendors/download/vendors-1.0.4.tgz",
       "integrity": "sha1-4rgApT56Kbk1BsPPQRANFsTErY4=",
       "dev": true
     },
@@ -16603,7 +16603,7 @@
     },
     "node_modules/vue-hot-reload-api": {
       "version": "2.3.4",
-      "resolved": "https://registry.npm.taobao.org/vue-hot-reload-api/download/vue-hot-reload-api-2.3.4.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-hot-reload-api/download/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha1-UylVzB6yCKPZkLOp+acFdGV+CPI=",
       "dev": true
     },
@@ -16618,7 +16618,7 @@
     },
     "node_modules/vue-loader": {
       "version": "15.9.6",
-      "resolved": "https://registry.npm.taobao.org/vue-loader/download/vue-loader-15.9.6.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-15.9.6.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-loader/download/vue-loader-15.9.6.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-15.9.6.tgz",
       "integrity": "sha1-9Lua4gw6g3CvPs8JuBJtOP/ba4s=",
       "dev": true,
       "dependencies": {
@@ -16636,7 +16636,7 @@
     "node_modules/vue-loader-v16": {
       "name": "vue-loader",
       "version": "16.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-loader/download/vue-loader-16.1.2.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-16.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-loader/download/vue-loader-16.1.2.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-16.1.2.tgz",
       "integrity": "sha1-XAO2xQ0qX5g8fOuhXFDXjKKymPQ=",
       "dev": true,
       "optional": true,
@@ -16648,7 +16648,7 @@
     },
     "node_modules/vue-loader-v16/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
       "dev": true,
       "optional": true,
@@ -16661,7 +16661,7 @@
     },
     "node_modules/vue-loader-v16/node_modules/chalk": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
       "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
       "dev": true,
       "optional": true,
@@ -16675,7 +16675,7 @@
     },
     "node_modules/vue-loader-v16/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/color-convert/download/color-convert-2.0.1.tgz",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
       "dev": true,
       "optional": true,
@@ -16688,14 +16688,14 @@
     },
     "node_modules/vue-loader-v16/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/color-name/download/color-name-1.1.4.tgz",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
       "dev": true,
       "optional": true
     },
     "node_modules/vue-loader-v16/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/has-flag/download/has-flag-4.0.0.tgz",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
       "dev": true,
       "optional": true,
@@ -16705,7 +16705,7 @@
     },
     "node_modules/vue-loader-v16/node_modules/loader-utils": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/loader-utils/download/loader-utils-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/loader-utils/download/loader-utils-2.0.0.tgz",
       "integrity": "sha1-5MrOW4FtQloWa18JfhDNErNgZLA=",
       "dev": true,
       "optional": true,
@@ -16720,7 +16720,7 @@
     },
     "node_modules/vue-loader-v16/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
       "dev": true,
       "optional": true,
@@ -16733,7 +16733,7 @@
     },
     "node_modules/vue-loader/node_modules/hash-sum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-1.0.2.tgz",
       "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
       "dev": true
     },
@@ -16803,7 +16803,7 @@
     },
     "node_modules/vue-style-loader": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-style-loader/download/vue-style-loader-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-style-loader/download/vue-style-loader-4.1.2.tgz",
       "integrity": "sha1-3t80mAbyXOtOZPOtfApE+6c1/Pg=",
       "dev": true,
       "dependencies": {
@@ -16813,7 +16813,7 @@
     },
     "node_modules/vue-style-loader/node_modules/hash-sum": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-1.0.2.tgz",
       "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
       "dev": true
     },
@@ -16829,7 +16829,7 @@
     },
     "node_modules/vue-template-es2015-compiler": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha1-HuO8mhbsv1EYvjNLsV+cRvgvWCU=",
       "dev": true
     },
@@ -17027,7 +17027,7 @@
     },
     "node_modules/wbuf": {
       "version": "1.7.3",
-      "resolved": "https://registry.npm.taobao.org/wbuf/download/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmmirror.com/wbuf/download/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "dev": true,
       "dependencies": {
@@ -17088,7 +17088,7 @@
     },
     "node_modules/webpack-bundle-analyzer": {
       "version": "3.9.0",
-      "resolved": "https://registry.npm.taobao.org/webpack-bundle-analyzer/download/webpack-bundle-analyzer-3.9.0.tgz?cache=0&sync_timestamp=1611221513167&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-bundle-analyzer%2Fdownload%2Fwebpack-bundle-analyzer-3.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-bundle-analyzer/download/webpack-bundle-analyzer-3.9.0.tgz?cache=0&sync_timestamp=1611221513167&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-bundle-analyzer%2Fdownload%2Fwebpack-bundle-analyzer-3.9.0.tgz",
       "integrity": "sha1-9vlNsQj7V05BWtMT3kGicH0z7zw=",
       "dev": true,
       "dependencies": {
@@ -17115,7 +17115,7 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
+      "resolved": "https://registry.npmmirror.com/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
       "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
       "dev": true,
       "bin": {
@@ -17136,7 +17136,7 @@
     },
     "node_modules/webpack-chain": {
       "version": "6.5.1",
-      "resolved": "https://registry.npm.taobao.org/webpack-chain/download/webpack-chain-6.5.1.tgz?cache=0&sync_timestamp=1595813261846&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-chain%2Fdownload%2Fwebpack-chain-6.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-chain/download/webpack-chain-6.5.1.tgz?cache=0&sync_timestamp=1595813261846&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-chain%2Fdownload%2Fwebpack-chain-6.5.1.tgz",
       "integrity": "sha1-TycoTLu2N+PI+970Pu9YjU2GEgY=",
       "dev": true,
       "dependencies": {
@@ -17149,7 +17149,7 @@
     },
     "node_modules/webpack-dev-middleware": {
       "version": "3.7.3",
-      "resolved": "https://registry.npm.taobao.org/webpack-dev-middleware/download/webpack-dev-middleware-3.7.3.tgz?cache=0&sync_timestamp=1610718844043&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-dev-middleware%2Fdownload%2Fwebpack-dev-middleware-3.7.3.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-dev-middleware/download/webpack-dev-middleware-3.7.3.tgz?cache=0&sync_timestamp=1610718844043&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-dev-middleware%2Fdownload%2Fwebpack-dev-middleware-3.7.3.tgz",
       "integrity": "sha1-Bjk3KxQyYuK4SrldO5GnWXBhwsU=",
       "dev": true,
       "dependencies": {
@@ -17223,7 +17223,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/anymatch": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/anymatch/download/anymatch-2.0.0.tgz",
       "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
       "dev": true,
       "dependencies": {
@@ -17233,7 +17233,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/anymatch/node_modules/normalize-path": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/normalize-path/download/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "dependencies": {
@@ -17245,7 +17245,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/binary-extensions": {
       "version": "1.13.1",
-      "resolved": "https://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.13.1.tgz?cache=0&sync_timestamp=1610299268308&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbinary-extensions%2Fdownload%2Fbinary-extensions-1.13.1.tgz",
+      "resolved": "https://registry.npmmirror.com/binary-extensions/download/binary-extensions-1.13.1.tgz?cache=0&sync_timestamp=1610299268308&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbinary-extensions%2Fdownload%2Fbinary-extensions-1.13.1.tgz",
       "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true,
       "engines": {
@@ -17277,7 +17277,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/fsevents": {
       "version": "1.2.13",
-      "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-1.2.13.tgz",
+      "resolved": "https://registry.npmmirror.com/fsevents/download/fsevents-1.2.13.tgz",
       "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
       "dev": true,
@@ -17293,7 +17293,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/glob-parent/download/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/glob-parent/download/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "dependencies": {
@@ -17303,7 +17303,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/glob-parent/node_modules/is-glob": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-glob/download/is-glob-3.1.0.tgz",
       "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
       "dev": true,
       "dependencies": {
@@ -17315,7 +17315,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/is-absolute-url": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-3.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/is-absolute-url/download/is-absolute-url-3.0.3.tgz",
       "integrity": "sha1-lsaiK2ojkpsR6gr7GDbDatSl1pg=",
       "dev": true,
       "engines": {
@@ -17324,7 +17324,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/is-binary-path/download/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "dependencies": {
@@ -17336,13 +17336,13 @@
     },
     "node_modules/webpack-dev-server/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/isarray/download/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "node_modules/webpack-dev-server/node_modules/readable-stream": {
       "version": "2.3.7",
-      "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz",
+      "resolved": "https://registry.npmmirror.com/readable-stream/download/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "dependencies": {
@@ -17357,7 +17357,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1602584394621&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1602584394621&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
       "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "dependencies": {
@@ -17371,7 +17371,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
       "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "dependencies": {
@@ -17385,7 +17385,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/semver": {
       "version": "6.3.0",
-      "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true,
       "bin": {
@@ -17394,7 +17394,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/string_decoder/download/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "dependencies": {
@@ -17403,7 +17403,7 @@
     },
     "node_modules/webpack-dev-server/node_modules/supports-color": {
       "version": "6.1.0",
-      "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-6.1.0.tgz",
       "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
       "dev": true,
       "dependencies": {
@@ -17437,7 +17437,7 @@
     },
     "node_modules/webpack-merge": {
       "version": "4.2.2",
-      "resolved": "https://registry.npm.taobao.org/webpack-merge/download/webpack-merge-4.2.2.tgz?cache=0&sync_timestamp=1608705461067&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-merge%2Fdownload%2Fwebpack-merge-4.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-merge/download/webpack-merge-4.2.2.tgz?cache=0&sync_timestamp=1608705461067&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-merge%2Fdownload%2Fwebpack-merge-4.2.2.tgz",
       "integrity": "sha1-onxS6ng9E5iv0gh/VH17nS9DY00=",
       "dev": true,
       "dependencies": {
@@ -17479,7 +17479,7 @@
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
-      "resolved": "https://registry.npm.taobao.org/websocket-driver/download/websocket-driver-0.7.4.tgz",
+      "resolved": "https://registry.npmmirror.com/websocket-driver/download/websocket-driver-0.7.4.tgz",
       "integrity": "sha1-ia1Slbv2S0gKvLox5JU6ynBvV2A=",
       "dev": true,
       "dependencies": {
@@ -17493,7 +17493,7 @@
     },
     "node_modules/websocket-extensions": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/websocket-extensions/download/websocket-extensions-0.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/websocket-extensions/download/websocket-extensions-0.1.4.tgz",
       "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI=",
       "dev": true,
       "engines": {
@@ -19378,7 +19378,7 @@
     },
     "@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/@intervolga/optimize-cssnano-plugin/download/@intervolga/optimize-cssnano-plugin-1.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@intervolga/optimize-cssnano-plugin/download/@intervolga/optimize-cssnano-plugin-1.0.6.tgz",
       "integrity": "sha1-vnx4RhKLiPapsdEmGgrQbrXA/fg=",
       "dev": true,
       "requires": {
@@ -19549,7 +19549,7 @@
     },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.8.0",
-      "resolved": "https://registry.npm.taobao.org/@soda/friendly-errors-webpack-plugin/download/@soda/friendly-errors-webpack-plugin-1.8.0.tgz?cache=0&sync_timestamp=1607927398894&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40soda%2Ffriendly-errors-webpack-plugin%2Fdownload%2F%40soda%2Ffriendly-errors-webpack-plugin-1.8.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@soda/friendly-errors-webpack-plugin/download/@soda/friendly-errors-webpack-plugin-1.8.0.tgz?cache=0&sync_timestamp=1607927398894&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40soda%2Ffriendly-errors-webpack-plugin%2Fdownload%2F%40soda%2Ffriendly-errors-webpack-plugin-1.8.0.tgz",
       "integrity": "sha1-hHUdgqkwGdXJLAzw5FrFkIfNIkA=",
       "dev": true,
       "requires": {
@@ -19561,13 +19561,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ansi-regex/download/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-5.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-5.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-5.2.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -19578,7 +19578,7 @@
     },
     "@soda/get-current-script": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/@soda/get-current-script/download/@soda/get-current-script-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@soda/get-current-script/download/@soda/get-current-script-1.0.2.tgz",
       "integrity": "sha1-pTUV2yXYA4N0OBtzryC7Ty5QjYc=",
       "dev": true
     },
@@ -19641,7 +19641,7 @@
     },
     "@types/anymatch": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/@types/anymatch/download/@types/anymatch-1.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/anymatch/download/@types/anymatch-1.3.1.tgz",
       "integrity": "sha1-M2utwb7sudrMOL6izzKt9ieoQho=",
       "dev": true
     },
@@ -19689,7 +19689,7 @@
     },
     "@types/connect-history-api-fallback": {
       "version": "1.3.3",
-      "resolved": "https://registry.npm.taobao.org/@types/connect-history-api-fallback/download/@types/connect-history-api-fallback-1.3.3.tgz?cache=0&sync_timestamp=1605052862677&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fconnect-history-api-fallback%2Fdownload%2F%40types%2Fconnect-history-api-fallback-1.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/connect-history-api-fallback/download/@types/connect-history-api-fallback-1.3.3.tgz?cache=0&sync_timestamp=1605052862677&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fconnect-history-api-fallback%2Fdownload%2F%40types%2Fconnect-history-api-fallback-1.3.3.tgz",
       "integrity": "sha1-R3K3m4tTGF8PTJ3qsJI2uvdu47Q=",
       "dev": true,
       "requires": {
@@ -19822,7 +19822,7 @@
     },
     "@types/http-proxy": {
       "version": "1.17.5",
-      "resolved": "https://registry.npm.taobao.org/@types/http-proxy/download/@types/http-proxy-1.17.5.tgz?cache=0&sync_timestamp=1610728394965&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fhttp-proxy%2Fdownload%2F%40types%2Fhttp-proxy-1.17.5.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/http-proxy/download/@types/http-proxy-1.17.5.tgz?cache=0&sync_timestamp=1610728394965&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fhttp-proxy%2Fdownload%2F%40types%2Fhttp-proxy-1.17.5.tgz",
       "integrity": "sha1-wgPF5uncaCDSekDrHlEccKIgQj0=",
       "dev": true,
       "requires": {
@@ -19831,7 +19831,7 @@
     },
     "@types/http-proxy-middleware": {
       "version": "0.19.3",
-      "resolved": "https://registry.npm.taobao.org/@types/http-proxy-middleware/download/@types/http-proxy-middleware-0.19.3.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/http-proxy-middleware/download/@types/http-proxy-middleware-0.19.3.tgz",
       "integrity": "sha1-suuW+8D5rHJQtdnExTqt4ElJfQM=",
       "dev": true,
       "requires": {
@@ -19941,7 +19941,7 @@
     },
     "@types/minimist": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/@types/minimist/download/@types/minimist-1.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/minimist/download/@types/minimist-1.2.1.tgz",
       "integrity": "sha1-KD9mn/dte4Jg34q3pCYsyD2YglY=",
       "dev": true
     },
@@ -19964,7 +19964,7 @@
     },
     "@types/q": {
       "version": "1.5.4",
-      "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.4.tgz?cache=0&sync_timestamp=1605055234302&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fq%2Fdownload%2F%40types%2Fq-1.5.4.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/q/download/@types/q-1.5.4.tgz?cache=0&sync_timestamp=1605055234302&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fq%2Fdownload%2F%40types%2Fq-1.5.4.tgz",
       "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
       "dev": true
     },
@@ -20009,7 +20009,7 @@
     },
     "@types/source-list-map": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/@types/source-list-map/download/@types/source-list-map-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/source-list-map/download/@types/source-list-map-0.1.2.tgz",
       "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
       "dev": true
     },
@@ -20026,13 +20026,13 @@
     },
     "@types/tapable": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/@types/tapable/download/@types/tapable-1.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/tapable/download/@types/tapable-1.0.6.tgz",
       "integrity": "sha1-qcpLcKGLJwzLK8Cqr+/R1Ia36nQ=",
       "dev": true
     },
     "@types/uglify-js": {
       "version": "3.12.0",
-      "resolved": "https://registry.npm.taobao.org/@types/uglify-js/download/@types/uglify-js-3.12.0.tgz?cache=0&sync_timestamp=1612680934348&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fuglify-js%2Fdownload%2F%40types%2Fuglify-js-3.12.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/uglify-js/download/@types/uglify-js-3.12.0.tgz?cache=0&sync_timestamp=1612680934348&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fuglify-js%2Fdownload%2F%40types%2Fuglify-js-3.12.0.tgz",
       "integrity": "sha1-K7BhwmlEFiDUa5RjUMjxbVLvN8U=",
       "dev": true,
       "requires": {
@@ -20041,7 +20041,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -20049,7 +20049,7 @@
     },
     "@types/webpack": {
       "version": "4.41.26",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack/download/@types/webpack-4.41.26.tgz?cache=0&sync_timestamp=1610402050021&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fwebpack%2Fdownload%2F%40types%2Fwebpack-4.41.26.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/webpack/download/@types/webpack-4.41.26.tgz?cache=0&sync_timestamp=1610402050021&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fwebpack%2Fdownload%2F%40types%2Fwebpack-4.41.26.tgz",
       "integrity": "sha1-J6MNfVMeFkifnHYHx0e+a8GkWe8=",
       "dev": true,
       "requires": {
@@ -20063,7 +20063,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -20071,7 +20071,7 @@
     },
     "@types/webpack-dev-server": {
       "version": "3.11.1",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack-dev-server/download/@types/webpack-dev-server-3.11.1.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/webpack-dev-server/download/@types/webpack-dev-server-3.11.1.tgz",
       "integrity": "sha1-+PTawdoibVML0VodXcNLI7p2bMs=",
       "dev": true,
       "requires": {
@@ -20084,7 +20084,7 @@
     },
     "@types/webpack-sources": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/@types/webpack-sources/download/@types/webpack-sources-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@types/webpack-sources/download/@types/webpack-sources-2.1.0.tgz",
       "integrity": "sha1-iIKwvWLR4M5i8YPQ0Bty5ugujBA=",
       "dev": true,
       "requires": {
@@ -20095,7 +20095,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.7.3",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.7.3.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.7.3.tgz",
           "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
           "dev": true
         }
@@ -20909,13 +20909,13 @@
       "dependencies": {
         "acorn": {
           "version": "7.4.1",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
+          "resolved": "https://registry.npmmirror.com/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
           "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
           "dev": true
         },
         "fs-extra": {
           "version": "7.0.1",
-          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-7.0.1.tgz?cache=0&sync_timestamp=1611075495956&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-7.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/fs-extra/download/fs-extra-7.0.1.tgz?cache=0&sync_timestamp=1611075495956&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffs-extra%2Fdownload%2Ffs-extra-7.0.1.tgz",
           "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
           "dev": true,
           "requires": {
@@ -20989,7 +20989,7 @@
     },
     "@vue/component-compiler-utils": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/component-compiler-utils/download/@vue/component-compiler-utils-3.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@vue/component-compiler-utils/download/@vue/component-compiler-utils-3.2.0.tgz",
       "integrity": "sha1-j4UYLO7Sjps8dTE95mn4MWbRHl0=",
       "dev": true,
       "requires": {
@@ -21006,13 +21006,13 @@
       "dependencies": {
         "hash-sum": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "https://registry.npm.taobao.org/lru-cache/download/lru-cache-4.1.5.tgz",
+          "resolved": "https://registry.npmmirror.com/lru-cache/download/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -21022,13 +21022,13 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-2.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/yallist/download/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -21036,14 +21036,14 @@
     },
     "@vue/preload-webpack-plugin": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/@vue/preload-webpack-plugin/download/@vue/preload-webpack-plugin-1.1.2.tgz?cache=0&sync_timestamp=1613215046917&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fpreload-webpack-plugin%2Fdownload%2F%40vue%2Fpreload-webpack-plugin-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/@vue/preload-webpack-plugin/download/@vue/preload-webpack-plugin-1.1.2.tgz?cache=0&sync_timestamp=1613215046917&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fpreload-webpack-plugin%2Fdownload%2F%40vue%2Fpreload-webpack-plugin-1.1.2.tgz",
       "integrity": "sha1-zrkktOyzucQ4ccekKaAvhCPmIas=",
       "dev": true,
       "requires": {}
     },
     "@vue/web-component-wrapper": {
       "version": "1.3.0",
-      "resolved": "https://registry.npm.taobao.org/@vue/web-component-wrapper/download/@vue/web-component-wrapper-1.3.0.tgz?cache=0&sync_timestamp=1613216636926&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fweb-component-wrapper%2Fdownload%2F%40vue%2Fweb-component-wrapper-1.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/@vue/web-component-wrapper/download/@vue/web-component-wrapper-1.3.0.tgz?cache=0&sync_timestamp=1613216636926&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40vue%2Fweb-component-wrapper%2Fdownload%2F%40vue%2Fweb-component-wrapper-1.3.0.tgz",
       "integrity": "sha1-trQKdiVCnSvXwigd26YB7QXcfxo=",
       "dev": true
     },
@@ -21323,13 +21323,13 @@
     },
     "acorn-walk": {
       "version": "7.2.0",
-      "resolved": "https://registry.npm.taobao.org/acorn-walk/download/acorn-walk-7.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/acorn-walk/download/acorn-walk-7.2.0.tgz",
       "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
       "dev": true
     },
     "address": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/address/download/address-1.1.2.tgz?cache=0&sync_timestamp=1593529661616&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Faddress%2Fdownload%2Faddress-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/address/download/address-1.1.2.tgz?cache=0&sync_timestamp=1593529661616&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Faddress%2Fdownload%2Faddress-1.1.2.tgz",
       "integrity": "sha1-vxEWycdYxRt6kz0pa3LCIe2UKLY=",
       "dev": true
     },
@@ -21364,7 +21364,7 @@
     },
     "alphanum-sort": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
@@ -21376,7 +21376,7 @@
     },
     "ansi-html": {
       "version": "0.0.7",
-      "resolved": "https://registry.npm.taobao.org/ansi-html/download/ansi-html-0.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/ansi-html/download/ansi-html-0.0.7.tgz",
       "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
       "dev": true
     },
@@ -21427,7 +21427,7 @@
     },
     "arch": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/arch/download/arch-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/arch/download/arch-2.2.0.tgz",
       "integrity": "sha1-G8R4GPMFdk8jqzMGsL/AhsWinRE=",
       "dev": true
     },
@@ -21472,7 +21472,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/array-flatten/download/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -21625,7 +21625,7 @@
     },
     "autoprefixer": {
       "version": "9.8.6",
-      "resolved": "https://registry.npm.taobao.org/autoprefixer/download/autoprefixer-9.8.6.tgz",
+      "resolved": "https://registry.npmmirror.com/autoprefixer/download/autoprefixer-9.8.6.tgz",
       "integrity": "sha1-O3NZTKG/kmYyDFrPFYjXTep0IQ8=",
       "dev": true,
       "requires": {
@@ -21781,7 +21781,7 @@
     },
     "batch": {
       "version": "0.6.1",
-      "resolved": "https://registry.npm.taobao.org/batch/download/batch-0.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/batch/download/batch-0.6.1.tgz",
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
@@ -21796,7 +21796,7 @@
     },
     "bfj": {
       "version": "6.1.2",
-      "resolved": "https://registry.npm.taobao.org/bfj/download/bfj-6.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/bfj/download/bfj-6.1.2.tgz",
       "integrity": "sha1-MlyGGoIryzWKQceKM7jm4ght3n8=",
       "dev": true,
       "requires": {
@@ -21892,7 +21892,7 @@
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "https://registry.npm.taobao.org/body-parser/download/body-parser-1.19.0.tgz",
+      "resolved": "https://registry.npmmirror.com/body-parser/download/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "dev": true,
       "requires": {
@@ -21910,7 +21910,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -21919,7 +21919,7 @@
         },
         "http-errors": {
           "version": "1.7.2",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz",
+          "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.7.2.tgz",
           "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
           "dev": true,
           "requires": {
@@ -21932,25 +21932,25 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
+          "resolved": "https://registry.npmmirror.com/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
           "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
           "dev": true
         }
@@ -21958,7 +21958,7 @@
     },
     "bonjour": {
       "version": "3.5.0",
-      "resolved": "https://registry.npm.taobao.org/bonjour/download/bonjour-3.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/bonjour/download/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "dev": true,
       "requires": {
@@ -21972,7 +21972,7 @@
       "dependencies": {
         "array-flatten": {
           "version": "2.1.2",
-          "resolved": "https://registry.npm.taobao.org/array-flatten/download/array-flatten-2.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/array-flatten/download/array-flatten-2.1.2.tgz",
           "integrity": "sha1-JO+AoowaiTYX4hSbDG0NeIKTsJk=",
           "dev": true
         }
@@ -21980,7 +21980,7 @@
     },
     "boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/boolbase/download/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
@@ -22165,7 +22165,7 @@
     },
     "buffer-indexof": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/buffer-indexof/download/buffer-indexof-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/buffer-indexof/download/buffer-indexof-1.1.1.tgz",
       "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
       "dev": true
     },
@@ -22200,7 +22200,7 @@
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.taobao.org/bytes/download/bytes-3.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/bytes/download/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
       "dev": true
     },
@@ -22392,7 +22392,7 @@
     },
     "caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/caller-callsite/download/caller-callsite-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/caller-callsite/download/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "requires": {
@@ -22401,7 +22401,7 @@
     },
     "caller-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/caller-path/download/caller-path-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/caller-path/download/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "requires": {
@@ -22410,13 +22410,13 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/callsites/download/callsites-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/callsites/download/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/camel-case/download/camel-case-3.0.0.tgz?cache=0&sync_timestamp=1606869170809&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamel-case%2Fdownload%2Fcamel-case-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/camel-case/download/camel-case-3.0.0.tgz?cache=0&sync_timestamp=1606869170809&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamel-case%2Fdownload%2Fcamel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -22432,7 +22432,7 @@
     },
     "caniuse-api": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/caniuse-api/download/caniuse-api-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/caniuse-api/download/caniuse-api-3.0.0.tgz",
       "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
       "dev": true,
       "requires": {
@@ -22450,7 +22450,7 @@
     },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
       "integrity": "sha1-I6xhPMmoVuT4j/i7c7u16YmCXPc=",
       "dev": true
     },
@@ -22499,7 +22499,7 @@
     },
     "check-types": {
       "version": "8.0.3",
-      "resolved": "https://registry.npm.taobao.org/check-types/download/check-types-8.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/check-types/download/check-types-8.0.3.tgz",
       "integrity": "sha1-M1bMoZyIlUTy16le1JzlCKDs9VI=",
       "dev": true
     },
@@ -22623,7 +22623,7 @@
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "https://registry.npm.taobao.org/clean-css/download/clean-css-4.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/clean-css/download/clean-css-4.2.3.tgz",
       "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
       "dev": true,
       "requires": {
@@ -22632,7 +22632,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -22649,7 +22649,7 @@
     },
     "cli-highlight": {
       "version": "2.1.10",
-      "resolved": "https://registry.npm.taobao.org/cli-highlight/download/cli-highlight-2.1.10.tgz?cache=0&sync_timestamp=1610119762804&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-highlight%2Fdownload%2Fcli-highlight-2.1.10.tgz",
+      "resolved": "https://registry.npmmirror.com/cli-highlight/download/cli-highlight-2.1.10.tgz?cache=0&sync_timestamp=1610119762804&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcli-highlight%2Fdownload%2Fcli-highlight-2.1.10.tgz",
       "integrity": "sha1-JqCH2pIJ3OT8uM9UJ9yXzZasFzo=",
       "dev": true,
       "requires": {
@@ -22663,13 +22663,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-regex/download/ansi-regex-5.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ansi-regex/download/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
@@ -22678,7 +22678,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
           "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
           "dev": true,
           "requires": {
@@ -22688,7 +22688,7 @@
         },
         "cliui": {
           "version": "7.0.4",
-          "resolved": "https://registry.npm.taobao.org/cliui/download/cliui-7.0.4.tgz",
+          "resolved": "https://registry.npmmirror.com/cliui/download/cliui-7.0.4.tgz",
           "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
           "dev": true,
           "requires": {
@@ -22699,7 +22699,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -22708,25 +22708,25 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmmirror.com/color-name/download/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/has-flag/download/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://registry.npm.taobao.org/string-width/download/string-width-4.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/string-width/download/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
@@ -22737,7 +22737,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npm.taobao.org/strip-ansi/download/strip-ansi-6.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-6.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/strip-ansi/download/strip-ansi-6.0.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstrip-ansi%2Fdownload%2Fstrip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
@@ -22746,7 +22746,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
@@ -22755,7 +22755,7 @@
         },
         "wrap-ansi": {
           "version": "7.0.0",
-          "resolved": "https://registry.npm.taobao.org/wrap-ansi/download/wrap-ansi-7.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/wrap-ansi/download/wrap-ansi-7.0.0.tgz",
           "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
           "dev": true,
           "requires": {
@@ -22766,13 +22766,13 @@
         },
         "y18n": {
           "version": "5.0.5",
-          "resolved": "https://registry.npm.taobao.org/y18n/download/y18n-5.0.5.tgz?cache=0&sync_timestamp=1609798693274&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-5.0.5.tgz",
+          "resolved": "https://registry.npmmirror.com/y18n/download/y18n-5.0.5.tgz?cache=0&sync_timestamp=1609798693274&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fy18n%2Fdownload%2Fy18n-5.0.5.tgz",
           "integrity": "sha1-h2nsCNA7HqLfJQCs71YXQ7u5qxg=",
           "dev": true
         },
         "yargs": {
           "version": "16.2.0",
-          "resolved": "https://registry.npm.taobao.org/yargs/download/yargs-16.2.0.tgz?cache=0&sync_timestamp=1610219751347&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-16.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs/download/yargs-16.2.0.tgz?cache=0&sync_timestamp=1610219751347&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fyargs%2Fdownload%2Fyargs-16.2.0.tgz",
           "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
           "dev": true,
           "requires": {
@@ -22787,7 +22787,7 @@
         },
         "yargs-parser": {
           "version": "20.2.5",
-          "resolved": "https://registry.npm.taobao.org/yargs-parser/download/yargs-parser-20.2.5.tgz",
+          "resolved": "https://registry.npmmirror.com/yargs-parser/download/yargs-parser-20.2.5.tgz",
           "integrity": "sha1-XTdykUbT+JTzn8lLZ5b1sjlRMYY=",
           "dev": true
         }
@@ -22801,7 +22801,7 @@
     },
     "clipboardy": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/clipboardy/download/clipboardy-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/clipboardy/download/clipboardy-2.3.0.tgz",
       "integrity": "sha1-PCkDZQxo5GqRs4iYW8J3QofbopA=",
       "dev": true,
       "requires": {
@@ -22812,7 +22812,7 @@
       "dependencies": {
         "is-wsl": {
           "version": "2.2.0",
-          "resolved": "https://registry.npm.taobao.org/is-wsl/download/is-wsl-2.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-wsl/download/is-wsl-2.2.0.tgz",
           "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
           "dev": true,
           "requires": {
@@ -22905,7 +22905,7 @@
     },
     "coa": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/coa/download/coa-2.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/coa/download/coa-2.0.2.tgz",
       "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
       "dev": true,
       "requires": {
@@ -23010,7 +23010,7 @@
     },
     "compressible": {
       "version": "2.0.18",
-      "resolved": "https://registry.npm.taobao.org/compressible/download/compressible-2.0.18.tgz",
+      "resolved": "https://registry.npmmirror.com/compressible/download/compressible-2.0.18.tgz",
       "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
       "dev": true,
       "requires": {
@@ -23019,7 +23019,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "https://registry.npm.taobao.org/compression/download/compression-1.7.4.tgz",
+      "resolved": "https://registry.npmmirror.com/compression/download/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "dev": true,
       "requires": {
@@ -23034,13 +23034,13 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.taobao.org/bytes/download/bytes-3.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/bytes/download/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -23049,7 +23049,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -23107,7 +23107,7 @@
     },
     "connect-history-api-fallback": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/connect-history-api-fallback/download/connect-history-api-fallback-1.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/connect-history-api-fallback/download/connect-history-api-fallback-1.6.0.tgz",
       "integrity": "sha1-izIIk1kwjRERFdgcrT/Oq4iPl7w=",
       "dev": true
     },
@@ -23119,7 +23119,7 @@
     },
     "consolidate": {
       "version": "0.15.1",
-      "resolved": "https://registry.npm.taobao.org/consolidate/download/consolidate-0.15.1.tgz",
+      "resolved": "https://registry.npmmirror.com/consolidate/download/consolidate-0.15.1.tgz",
       "integrity": "sha1-IasEMjXHGgfUXZqtmFk7DbpWurc=",
       "dev": true,
       "requires": {
@@ -23161,7 +23161,7 @@
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.taobao.org/cookie-signature/download/cookie-signature-1.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/download/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
@@ -23327,7 +23327,7 @@
     },
     "cosmiconfig": {
       "version": "5.2.1",
-      "resolved": "https://registry.npm.taobao.org/cosmiconfig/download/cosmiconfig-5.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cosmiconfig/download/cosmiconfig-5.2.1.tgz",
       "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
       "dev": true,
       "requires": {
@@ -23339,7 +23339,7 @@
       "dependencies": {
         "parse-json": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/parse-json/download/parse-json-4.0.0.tgz?cache=0&sync_timestamp=1610966642419&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse-json%2Fdownload%2Fparse-json-4.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/parse-json/download/parse-json-4.0.0.tgz?cache=0&sync_timestamp=1610966642419&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse-json%2Fdownload%2Fparse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "dev": true,
           "requires": {
@@ -23464,13 +23464,13 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npm.taobao.org/css-color-names/download/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/css-color-names/download/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
     "css-declaration-sorter": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/css-declaration-sorter/download/css-declaration-sorter-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/css-declaration-sorter/download/css-declaration-sorter-4.0.1.tgz",
       "integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
       "dev": true,
       "requires": {
@@ -23480,7 +23480,7 @@
     },
     "css-loader": {
       "version": "3.6.0",
-      "resolved": "https://registry.npm.taobao.org/css-loader/download/css-loader-3.6.0.tgz?cache=0&sync_timestamp=1612791290346&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-loader%2Fdownload%2Fcss-loader-3.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/css-loader/download/css-loader-3.6.0.tgz?cache=0&sync_timestamp=1612791290346&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-loader%2Fdownload%2Fcss-loader-3.6.0.tgz",
       "integrity": "sha1-Lkssfm4tJ/jI8o9hv/zS5ske9kU=",
       "dev": true,
       "requires": {
@@ -23501,13 +23501,13 @@
       "dependencies": {
         "camelcase": {
           "version": "5.3.1",
-          "resolved": "https://registry.npm.taobao.org/camelcase/download/camelcase-5.3.1.tgz?cache=0&sync_timestamp=1603921884289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamelcase%2Fdownload%2Fcamelcase-5.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/camelcase/download/camelcase-5.3.1.tgz?cache=0&sync_timestamp=1603921884289&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcamelcase%2Fdownload%2Fcamelcase-5.3.1.tgz",
           "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
           "dev": true
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -23515,7 +23515,7 @@
     },
     "css-select": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/css-select/download/css-select-2.1.0.tgz?cache=0&sync_timestamp=1608486296143&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-select%2Fdownload%2Fcss-select-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/css-select/download/css-select-2.1.0.tgz?cache=0&sync_timestamp=1608486296143&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-select%2Fdownload%2Fcss-select-2.1.0.tgz",
       "integrity": "sha1-ajRlM1ZjWTSoG6ymjQJVQyEF2+8=",
       "dev": true,
       "requires": {
@@ -23527,13 +23527,13 @@
     },
     "css-select-base-adapter": {
       "version": "0.1.1",
-      "resolved": "https://registry.npm.taobao.org/css-select-base-adapter/download/css-select-base-adapter-0.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/css-select-base-adapter/download/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc=",
       "dev": true
     },
     "css-tree": {
       "version": "1.0.0-alpha.37",
-      "resolved": "https://registry.npm.taobao.org/css-tree/download/css-tree-1.0.0-alpha.37.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.0.0-alpha.37.tgz",
+      "resolved": "https://registry.npmmirror.com/css-tree/download/css-tree-1.0.0-alpha.37.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.0.0-alpha.37.tgz",
       "integrity": "sha1-mL69YsTB2flg7DQM+fdSLjBwmiI=",
       "dev": true,
       "requires": {
@@ -23543,7 +23543,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -23551,19 +23551,19 @@
     },
     "css-what": {
       "version": "3.4.2",
-      "resolved": "https://registry.npm.taobao.org/css-what/download/css-what-3.4.2.tgz?cache=0&sync_timestamp=1602570915327&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-3.4.2.tgz",
+      "resolved": "https://registry.npmmirror.com/css-what/download/css-what-3.4.2.tgz?cache=0&sync_timestamp=1602570915327&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-3.4.2.tgz",
       "integrity": "sha1-6nAm/LAXd+295SEk4h8yfnrpUOQ=",
       "dev": true
     },
     "cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssesc/download/cssesc-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cssesc/download/cssesc-3.0.0.tgz",
       "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
       "dev": true
     },
     "cssnano": {
       "version": "4.1.10",
-      "resolved": "https://registry.npm.taobao.org/cssnano/download/cssnano-4.1.10.tgz?cache=0&sync_timestamp=1612632668700&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano%2Fdownload%2Fcssnano-4.1.10.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano/download/cssnano-4.1.10.tgz?cache=0&sync_timestamp=1612632668700&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano%2Fdownload%2Fcssnano-4.1.10.tgz",
       "integrity": "sha1-CsQfCxPRPUZUh+ERt3jULaYxuLI=",
       "dev": true,
       "requires": {
@@ -23575,7 +23575,7 @@
     },
     "cssnano-preset-default": {
       "version": "4.0.7",
-      "resolved": "https://registry.npm.taobao.org/cssnano-preset-default/download/cssnano-preset-default-4.0.7.tgz?cache=0&sync_timestamp=1612632637438&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano-preset-default%2Fdownload%2Fcssnano-preset-default-4.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-preset-default/download/cssnano-preset-default-4.0.7.tgz?cache=0&sync_timestamp=1612632637438&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcssnano-preset-default%2Fdownload%2Fcssnano-preset-default-4.0.7.tgz",
       "integrity": "sha1-UexmLM/KD4izltzZZ5zbkxvhf3Y=",
       "dev": true,
       "requires": {
@@ -23613,19 +23613,19 @@
     },
     "cssnano-util-get-arguments": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
       "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
       "dev": true
     },
     "cssnano-util-get-match": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
       "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
       "dev": true
     },
     "cssnano-util-raw-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-raw-cache/download/cssnano-util-raw-cache-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-raw-cache/download/cssnano-util-raw-cache-4.0.1.tgz",
       "integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
       "dev": true,
       "requires": {
@@ -23634,13 +23634,13 @@
     },
     "cssnano-util-same-parent": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/cssnano-util-same-parent/download/cssnano-util-same-parent-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/cssnano-util-same-parent/download/cssnano-util-same-parent-4.0.1.tgz",
       "integrity": "sha1-V0CC+yhZ0ttDOFWDXZqEVuoYu/M=",
       "dev": true
     },
     "csso": {
       "version": "4.2.0",
-      "resolved": "https://registry.npm.taobao.org/csso/download/csso-4.2.0.tgz?cache=0&sync_timestamp=1606408849393&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcsso%2Fdownload%2Fcsso-4.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/csso/download/csso-4.2.0.tgz?cache=0&sync_timestamp=1606408849393&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcsso%2Fdownload%2Fcsso-4.2.0.tgz",
       "integrity": "sha1-6jpWE0bo3J9UbW/r7dUBh884lSk=",
       "dev": true,
       "requires": {
@@ -23649,7 +23649,7 @@
       "dependencies": {
         "css-tree": {
           "version": "1.1.2",
-          "resolved": "https://registry.npm.taobao.org/css-tree/download/css-tree-1.1.2.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/css-tree/download/css-tree-1.1.2.tgz?cache=0&sync_timestamp=1606404102945&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-tree%2Fdownload%2Fcss-tree-1.1.2.tgz",
           "integrity": "sha1-muOTtdr9fa6KYiR1yux409j717U=",
           "dev": true,
           "requires": {
@@ -23659,13 +23659,13 @@
         },
         "mdn-data": {
           "version": "2.0.14",
-          "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.14.tgz",
+          "resolved": "https://registry.npmmirror.com/mdn-data/download/mdn-data-2.0.14.tgz",
           "integrity": "sha1-cRP8QoGRfWPOKbQ0RvcB5owlulA=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -23755,7 +23755,7 @@
     },
     "default-gateway": {
       "version": "5.0.5",
-      "resolved": "https://registry.npm.taobao.org/default-gateway/download/default-gateway-5.0.5.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-5.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/default-gateway/download/default-gateway-5.0.5.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-5.0.5.tgz",
       "integrity": "sha1-T9a9XShV05s0zFpZUFSG6ar8mxA=",
       "dev": true,
       "requires": {
@@ -23764,7 +23764,7 @@
       "dependencies": {
         "execa": {
           "version": "3.4.0",
-          "resolved": "https://registry.npm.taobao.org/execa/download/execa-3.4.0.tgz?cache=0&sync_timestamp=1606971018065&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-3.4.0.tgz",
+          "resolved": "https://registry.npmmirror.com/execa/download/execa-3.4.0.tgz?cache=0&sync_timestamp=1606971018065&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexeca%2Fdownload%2Fexeca-3.4.0.tgz",
           "integrity": "sha1-wI7UVQ72XYWPrCaf/IVyRG8364k=",
           "dev": true,
           "requires": {
@@ -23782,19 +23782,19 @@
         },
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-stream/download/is-stream-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-stream/download/is-stream-2.0.0.tgz",
           "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM=",
           "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/mimic-fn/download/mimic-fn-2.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/mimic-fn/download/mimic-fn-2.1.0.tgz",
           "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
           "dev": true
         },
         "npm-run-path": {
           "version": "4.0.1",
-          "resolved": "https://registry.npm.taobao.org/npm-run-path/download/npm-run-path-4.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/npm-run-path/download/npm-run-path-4.0.1.tgz",
           "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
           "dev": true,
           "requires": {
@@ -23803,7 +23803,7 @@
         },
         "onetime": {
           "version": "5.1.2",
-          "resolved": "https://registry.npm.taobao.org/onetime/download/onetime-5.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/onetime/download/onetime-5.1.2.tgz",
           "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
           "dev": true,
           "requires": {
@@ -23812,7 +23812,7 @@
         },
         "p-finally": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/p-finally/download/p-finally-2.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/p-finally/download/p-finally-2.0.1.tgz",
           "integrity": "sha1-vW/KqcVZoJa2gIBvTWV7Pw8kBWE=",
           "dev": true
         }
@@ -23927,7 +23927,7 @@
     },
     "del": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/del/download/del-4.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/del/download/del-4.1.1.tgz",
       "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
       "dev": true,
       "requires": {
@@ -23942,7 +23942,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/globby/download/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/globby/download/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -23955,7 +23955,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "https://registry.npm.taobao.org/pify/download/pify-2.3.0.tgz?cache=0&sync_timestamp=1593529716831&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpify%2Fdownload%2Fpify-2.3.0.tgz",
+              "resolved": "https://registry.npmmirror.com/pify/download/pify-2.3.0.tgz?cache=0&sync_timestamp=1593529716831&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpify%2Fdownload%2Fpify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -23963,7 +23963,7 @@
         },
         "p-map": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/p-map/download/p-map-2.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/p-map/download/p-map-2.1.0.tgz",
           "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
           "dev": true
         }
@@ -24002,7 +24002,7 @@
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/detect-node/download/detect-node-2.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/detect-node/download/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
       "dev": true
     },
@@ -24042,7 +24042,7 @@
     },
     "dns-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/dns-equal/download/dns-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dns-equal/download/dns-equal-1.0.0.tgz",
       "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
       "dev": true
     },
@@ -24058,7 +24058,7 @@
     },
     "dns-txt": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.taobao.org/dns-txt/download/dns-txt-2.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/dns-txt/download/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "dev": true,
       "requires": {
@@ -24067,7 +24067,7 @@
     },
     "dom-converter": {
       "version": "0.2.0",
-      "resolved": "https://registry.npm.taobao.org/dom-converter/download/dom-converter-0.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dom-converter/download/dom-converter-0.2.0.tgz",
       "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
       "dev": true,
       "requires": {
@@ -24076,7 +24076,7 @@
     },
     "dom-serializer": {
       "version": "0.2.2",
-      "resolved": "https://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.2.2.tgz?cache=0&sync_timestamp=1607193380961&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdom-serializer%2Fdownload%2Fdom-serializer-0.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/dom-serializer/download/dom-serializer-0.2.2.tgz?cache=0&sync_timestamp=1607193380961&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdom-serializer%2Fdownload%2Fdom-serializer-0.2.2.tgz",
       "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
       "dev": true,
       "requires": {
@@ -24086,7 +24086,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-2.1.0.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-2.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/domelementtype/download/domelementtype-2.1.0.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-2.1.0.tgz",
           "integrity": "sha1-qFHAgKbRw9lDRK7RUdmfZp7fWF4=",
           "dev": true
         }
@@ -24100,7 +24100,7 @@
     },
     "domelementtype": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-1.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/domelementtype/download/domelementtype-1.3.1.tgz?cache=0&sync_timestamp=1606865995285&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomelementtype%2Fdownload%2Fdomelementtype-1.3.1.tgz",
       "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
       "dev": true
     },
@@ -24123,7 +24123,7 @@
     },
     "domutils": {
       "version": "1.7.0",
-      "resolved": "https://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz?cache=0&sync_timestamp=1607393056952&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomutils%2Fdownload%2Fdomutils-1.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/domutils/download/domutils-1.7.0.tgz?cache=0&sync_timestamp=1607393056952&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdomutils%2Fdownload%2Fdomutils-1.7.0.tgz",
       "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
       "dev": true,
       "requires": {
@@ -24170,7 +24170,7 @@
     },
     "dot-prop": {
       "version": "5.3.0",
-      "resolved": "https://registry.npm.taobao.org/dot-prop/download/dot-prop-5.3.0.tgz?cache=0&sync_timestamp=1605778245785&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdot-prop%2Fdownload%2Fdot-prop-5.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dot-prop/download/dot-prop-5.3.0.tgz?cache=0&sync_timestamp=1605778245785&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdot-prop%2Fdownload%2Fdot-prop-5.3.0.tgz",
       "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
       "dev": true,
       "requires": {
@@ -24179,7 +24179,7 @@
       "dependencies": {
         "is-obj": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/is-obj/download/is-obj-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/is-obj/download/is-obj-2.0.0.tgz",
           "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI=",
           "dev": true
         }
@@ -24187,19 +24187,19 @@
     },
     "dotenv": {
       "version": "8.2.0",
-      "resolved": "https://registry.npm.taobao.org/dotenv/download/dotenv-8.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dotenv/download/dotenv-8.2.0.tgz",
       "integrity": "sha1-l+YZJZradQ7qPk6j4mvO6lQksWo=",
       "dev": true
     },
     "dotenv-expand": {
       "version": "5.1.0",
-      "resolved": "https://registry.npm.taobao.org/dotenv-expand/download/dotenv-expand-5.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/dotenv-expand/download/dotenv-expand-5.1.0.tgz",
       "integrity": "sha1-P7rwIL/XlIhAcuomsel5HUWmKfA=",
       "dev": true
     },
     "duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/duplexer/download/duplexer-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/duplexer/download/duplexer-0.1.2.tgz",
       "integrity": "sha1-Or5DrvODX4rgd9E23c4PJ2sEAOY=",
       "dev": true
     },
@@ -24298,7 +24298,7 @@
     },
     "ejs": {
       "version": "2.7.4",
-      "resolved": "https://registry.npm.taobao.org/ejs/download/ejs-2.7.4.tgz",
+      "resolved": "https://registry.npmmirror.com/ejs/download/ejs-2.7.4.tgz",
       "integrity": "sha1-SGYSh1c9zFPjZsehrlLDoSDuybo=",
       "dev": true
     },
@@ -24491,7 +24491,7 @@
     },
     "entities": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/entities/download/entities-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/entities/download/entities-2.2.0.tgz",
       "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU=",
       "dev": true
     },
@@ -24514,7 +24514,7 @@
     },
     "error-stack-parser": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/error-stack-parser/download/error-stack-parser-2.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/error-stack-parser/download/error-stack-parser-2.0.6.tgz",
       "integrity": "sha1-WpmnB716TFinl5AtSNgoA+3mqtg=",
       "dev": true,
       "requires": {
@@ -24566,7 +24566,7 @@
     },
     "escalade": {
       "version": "3.1.1",
-      "resolved": "https://registry.npm.taobao.org/escalade/download/escalade-3.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/escalade/download/escalade-3.1.1.tgz",
       "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
       "dev": true
     },
@@ -24634,7 +24634,7 @@
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npm.taobao.org/etag/download/etag-1.8.1.tgz",
+      "resolved": "https://registry.npmmirror.com/etag/download/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
@@ -24646,7 +24646,7 @@
     },
     "eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npm.taobao.org/eventemitter3/download/eventemitter3-4.0.7.tgz?cache=0&sync_timestamp=1598517819668&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feventemitter3%2Fdownload%2Feventemitter3-4.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/eventemitter3/download/eventemitter3-4.0.7.tgz?cache=0&sync_timestamp=1598517819668&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Feventemitter3%2Fdownload%2Feventemitter3-4.0.7.tgz",
       "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
       "dev": true
     },
@@ -24658,7 +24658,7 @@
     },
     "eventsource": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/eventsource/download/eventsource-1.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/eventsource/download/eventsource-1.0.7.tgz",
       "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
       "dev": true,
       "requires": {
@@ -24796,7 +24796,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "https://registry.npm.taobao.org/express/download/express-4.17.1.tgz?cache=0&sync_timestamp=1596722127254&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexpress%2Fdownload%2Fexpress-4.17.1.tgz",
+      "resolved": "https://registry.npmmirror.com/express/download/express-4.17.1.tgz?cache=0&sync_timestamp=1596722127254&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fexpress%2Fdownload%2Fexpress-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "dev": true,
       "requires": {
@@ -24834,13 +24834,13 @@
       "dependencies": {
         "cookie": {
           "version": "0.4.0",
-          "resolved": "https://registry.npm.taobao.org/cookie/download/cookie-0.4.0.tgz",
+          "resolved": "https://registry.npmmirror.com/cookie/download/cookie-0.4.0.tgz",
           "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -24849,25 +24849,25 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "resolved": "https://registry.npm.taobao.org/path-to-regexp/download/path-to-regexp-0.1.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath-to-regexp%2Fdownload%2Fpath-to-regexp-0.1.7.tgz",
+          "resolved": "https://registry.npmmirror.com/path-to-regexp/download/path-to-regexp-0.1.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpath-to-regexp%2Fdownload%2Fpath-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "https://registry.npm.taobao.org/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
+          "resolved": "https://registry.npmmirror.com/qs/download/qs-6.7.0.tgz?cache=0&sync_timestamp=1610598229410&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fqs%2Fdownload%2Fqs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
           "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
           "dev": true
         }
@@ -25022,7 +25022,7 @@
     },
     "faye-websocket": {
       "version": "0.11.3",
-      "resolved": "https://registry.npm.taobao.org/faye-websocket/download/faye-websocket-0.11.3.tgz",
+      "resolved": "https://registry.npmmirror.com/faye-websocket/download/faye-websocket-0.11.3.tgz",
       "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
       "dev": true,
       "requires": {
@@ -25037,7 +25037,7 @@
     },
     "file-loader": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/file-loader/download/file-loader-4.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/file-loader/download/file-loader-4.3.0.tgz",
       "integrity": "sha1-eA8ED3KbPRgBnyBgX3I+hEuKWK8=",
       "dev": true,
       "requires": {
@@ -25054,7 +25054,7 @@
     },
     "filesize": {
       "version": "3.6.1",
-      "resolved": "https://registry.npm.taobao.org/filesize/download/filesize-3.6.1.tgz",
+      "resolved": "https://registry.npmmirror.com/filesize/download/filesize-3.6.1.tgz",
       "integrity": "sha1-CQuz7gG2+AGoqL6Z0xcQs0Irsxc=",
       "dev": true
     },
@@ -25083,7 +25083,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/finalhandler/download/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/finalhandler/download/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "dev": true,
       "requires": {
@@ -25098,7 +25098,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -25107,7 +25107,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -25183,7 +25183,7 @@
     },
     "follow-redirects": {
       "version": "1.13.2",
-      "resolved": "https://registry.npm.taobao.org/follow-redirects/download/follow-redirects-1.13.2.tgz?cache=0&sync_timestamp=1611606737937&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffollow-redirects%2Fdownload%2Ffollow-redirects-1.13.2.tgz",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/download/follow-redirects-1.13.2.tgz?cache=0&sync_timestamp=1611606737937&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ffollow-redirects%2Fdownload%2Ffollow-redirects-1.13.2.tgz",
       "integrity": "sha1-3XPI7/wScoulz0JZ12DqX7g+MUc=",
       "dev": true
     },
@@ -25259,7 +25259,7 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/forwarded/download/forwarded-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/forwarded/download/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
@@ -25524,7 +25524,7 @@
     },
     "gzip-size": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/gzip-size/download/gzip-size-5.1.1.tgz?cache=0&sync_timestamp=1605523125680&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgzip-size%2Fdownload%2Fgzip-size-5.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/gzip-size/download/gzip-size-5.1.1.tgz?cache=0&sync_timestamp=1605523125680&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fgzip-size%2Fdownload%2Fgzip-size-5.1.1.tgz",
       "integrity": "sha1-y5vuaS+HwGErIyhAqHOQTkwTUnQ=",
       "dev": true,
       "requires": {
@@ -25534,7 +25534,7 @@
     },
     "handle-thing": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/handle-thing/download/handle-thing-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/handle-thing/download/handle-thing-2.0.1.tgz",
       "integrity": "sha1-hX95zjWVgMNA1DCBzGSJcNC7I04=",
       "dev": true
     },
@@ -25648,7 +25648,7 @@
     },
     "hash-sum": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-2.0.0.tgz",
       "integrity": "sha1-gdAbtd6OpKIUrV1urRtSNGCwtFo=",
       "dev": true
     },
@@ -25684,13 +25684,13 @@
     },
     "hex-color-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/hex-color-regex/download/hex-color-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hex-color-regex/download/hex-color-regex-1.1.0.tgz",
       "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=",
       "dev": true
     },
     "highlight.js": {
       "version": "10.6.0",
-      "resolved": "https://registry.npm.taobao.org/highlight.js/download/highlight.js-10.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/highlight.js/download/highlight.js-10.6.0.tgz",
       "integrity": "sha1-AHOqcdVmkGllum4be+eyaC9eGLY=",
       "dev": true
     },
@@ -25707,7 +25707,7 @@
     },
     "hoopy": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/hoopy/download/hoopy-0.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/hoopy/download/hoopy-0.1.4.tgz",
       "integrity": "sha1-YJIH1mEQADOpqUAq096mdzgcGx0=",
       "dev": true
     },
@@ -25719,7 +25719,7 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "https://registry.npm.taobao.org/hpack.js/download/hpack.js-2.1.6.tgz",
+      "resolved": "https://registry.npmmirror.com/hpack.js/download/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -25731,13 +25731,13 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/isarray/download/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
-          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz",
+          "resolved": "https://registry.npmmirror.com/readable-stream/download/readable-stream-2.3.7.tgz",
           "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
           "dev": true,
           "requires": {
@@ -25752,7 +25752,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
@@ -25763,25 +25763,25 @@
     },
     "hsl-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsl-regex/download/hsl-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hsl-regex/download/hsl-regex-1.0.0.tgz",
       "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
       "dev": true
     },
     "hsla-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/hsla-regex/download/hsla-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/hsla-regex/download/hsla-regex-1.0.0.tgz",
       "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
       "dev": true
     },
     "html-comment-regex": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
       "integrity": "sha1-l9RoiutcgYhqNk+qDK0d2hTUM6c=",
       "dev": true
     },
     "html-entities": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.taobao.org/html-entities/download/html-entities-1.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-entities%2Fdownload%2Fhtml-entities-1.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/html-entities/download/html-entities-1.4.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-entities%2Fdownload%2Fhtml-entities-1.4.0.tgz",
       "integrity": "sha1-z70bAdKvr5rcobEK59/6uYxx0tw=",
       "dev": true
     },
@@ -25793,7 +25793,7 @@
     },
     "html-minifier": {
       "version": "3.5.21",
-      "resolved": "https://registry.npm.taobao.org/html-minifier/download/html-minifier-3.5.21.tgz",
+      "resolved": "https://registry.npmmirror.com/html-minifier/download/html-minifier-3.5.21.tgz",
       "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
       "dev": true,
       "requires": {
@@ -25808,7 +25808,7 @@
       "dependencies": {
         "commander": {
           "version": "2.17.1",
-          "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.17.1.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.17.1.tgz",
+          "resolved": "https://registry.npmmirror.com/commander/download/commander-2.17.1.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.17.1.tgz",
           "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true
         }
@@ -25871,7 +25871,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "https://registry.npm.taobao.org/html-webpack-plugin/download/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/html-webpack-plugin/download/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -25886,25 +25886,25 @@
       "dependencies": {
         "big.js": {
           "version": "3.2.0",
-          "resolved": "https://registry.npm.taobao.org/big.js/download/big.js-3.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/big.js/download/big.js-3.2.0.tgz",
           "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
           "dev": true
         },
         "emojis-list": {
           "version": "2.1.0",
-          "resolved": "https://registry.npm.taobao.org/emojis-list/download/emojis-list-2.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/emojis-list/download/emojis-list-2.1.0.tgz",
           "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
           "dev": true
         },
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npm.taobao.org/json5/download/json5-0.5.1.tgz?cache=0&sync_timestamp=1612146079519&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-0.5.1.tgz",
+          "resolved": "https://registry.npmmirror.com/json5/download/json5-0.5.1.tgz?cache=0&sync_timestamp=1612146079519&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjson5%2Fdownload%2Fjson5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
         "loader-utils": {
           "version": "0.2.17",
-          "resolved": "https://registry.npm.taobao.org/loader-utils/download/loader-utils-0.2.17.tgz",
+          "resolved": "https://registry.npmmirror.com/loader-utils/download/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "dev": true,
           "requires": {
@@ -25993,7 +25993,7 @@
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "https://registry.npm.taobao.org/http-deceiver/download/http-deceiver-1.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/http-deceiver/download/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
@@ -26011,13 +26011,13 @@
     },
     "http-parser-js": {
       "version": "0.5.3",
-      "resolved": "https://registry.npm.taobao.org/http-parser-js/download/http-parser-js-0.5.3.tgz?cache=0&sync_timestamp=1609542336109&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-parser-js%2Fdownload%2Fhttp-parser-js-0.5.3.tgz",
+      "resolved": "https://registry.npmmirror.com/http-parser-js/download/http-parser-js-0.5.3.tgz?cache=0&sync_timestamp=1609542336109&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-parser-js%2Fdownload%2Fhttp-parser-js-0.5.3.tgz",
       "integrity": "sha1-AdJwnHnUFpi7AdTezF6dpOSgM9k=",
       "dev": true
     },
     "http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy/download/http-proxy-1.18.1.tgz",
+      "resolved": "https://registry.npmmirror.com/http-proxy/download/http-proxy-1.18.1.tgz",
       "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
       "dev": true,
       "requires": {
@@ -26028,7 +26028,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.19.1",
-      "resolved": "https://registry.npm.taobao.org/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz?cache=0&sync_timestamp=1602445480546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-proxy-middleware%2Fdownload%2Fhttp-proxy-middleware-0.19.1.tgz",
+      "resolved": "https://registry.npmmirror.com/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz?cache=0&sync_timestamp=1602445480546&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhttp-proxy-middleware%2Fdownload%2Fhttp-proxy-middleware-0.19.1.tgz",
       "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
       "dev": true,
       "requires": {
@@ -26057,7 +26057,7 @@
     },
     "human-signals": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/human-signals/download/human-signals-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/human-signals/download/human-signals-1.1.1.tgz",
       "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
       "dev": true
     },
@@ -26072,7 +26072,7 @@
     },
     "icss-utils": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.taobao.org/icss-utils/download/icss-utils-4.1.1.tgz?cache=0&sync_timestamp=1605801375650&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ficss-utils%2Fdownload%2Ficss-utils-4.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/icss-utils/download/icss-utils-4.1.1.tgz?cache=0&sync_timestamp=1605801375650&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ficss-utils%2Fdownload%2Ficss-utils-4.1.1.tgz",
       "integrity": "sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=",
       "dev": true,
       "requires": {
@@ -26103,7 +26103,7 @@
     },
     "import-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/import-cwd/download/import-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-cwd/download/import-cwd-2.1.0.tgz",
       "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
       "dev": true,
       "requires": {
@@ -26112,7 +26112,7 @@
     },
     "import-fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-fresh/download/import-fresh-2.0.0.tgz?cache=0&sync_timestamp=1608469472392&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-fresh/download/import-fresh-2.0.0.tgz?cache=0&sync_timestamp=1608469472392&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fimport-fresh%2Fdownload%2Fimport-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
       "dev": true,
       "requires": {
@@ -26122,7 +26122,7 @@
     },
     "import-from": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/import-from/download/import-from-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-from/download/import-from-2.1.0.tgz",
       "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
       "dev": true,
       "requires": {
@@ -26131,7 +26131,7 @@
     },
     "import-local": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/import-local/download/import-local-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/import-local/download/import-local-2.0.0.tgz",
       "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
       "dev": true,
       "requires": {
@@ -26147,7 +26147,7 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/indexes-of/download/indexes-of-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/indexes-of/download/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
       "dev": true
     },
@@ -26179,7 +26179,7 @@
     },
     "internal-ip": {
       "version": "4.3.0",
-      "resolved": "https://registry.npm.taobao.org/internal-ip/download/internal-ip-4.3.0.tgz?cache=0&sync_timestamp=1605885556992&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finternal-ip%2Fdownload%2Finternal-ip-4.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/internal-ip/download/internal-ip-4.3.0.tgz?cache=0&sync_timestamp=1605885556992&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finternal-ip%2Fdownload%2Finternal-ip-4.3.0.tgz",
       "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
       "dev": true,
       "requires": {
@@ -26189,7 +26189,7 @@
       "dependencies": {
         "default-gateway": {
           "version": "4.2.0",
-          "resolved": "https://registry.npm.taobao.org/default-gateway/download/default-gateway-4.2.0.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-4.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/default-gateway/download/default-gateway-4.2.0.tgz?cache=0&sync_timestamp=1610365857779&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdefault-gateway%2Fdownload%2Fdefault-gateway-4.2.0.tgz",
           "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
           "dev": true,
           "requires": {
@@ -26210,25 +26210,25 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://registry.npm.taobao.org/ip/download/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmmirror.com/ip/download/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/ip-regex/download/ip-regex-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ip-regex/download/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/ipaddr.js/download/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/download/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "dev": true
     },
     "is-absolute-url": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
       "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
       "dev": true
     },
@@ -26281,7 +26281,7 @@
     },
     "is-color-stop": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-color-stop/download/is-color-stop-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-color-stop/download/is-color-stop-1.1.0.tgz",
       "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
       "dev": true,
       "requires": {
@@ -26349,13 +26349,13 @@
     },
     "is-directory": {
       "version": "0.3.1",
-      "resolved": "https://registry.npm.taobao.org/is-directory/download/is-directory-0.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/is-directory/download/is-directory-0.3.1.tgz",
       "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
       "dev": true
     },
     "is-docker": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/is-docker/download/is-docker-2.1.1.tgz?cache=0&sync_timestamp=1596559460885&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-docker%2Fdownload%2Fis-docker-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/is-docker/download/is-docker-2.1.1.tgz?cache=0&sync_timestamp=1596559460885&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fis-docker%2Fdownload%2Fis-docker-2.1.1.tgz",
       "integrity": "sha1-QSWojkTkUNOE4JBH7eca3C0UQVY=",
       "dev": true
     },
@@ -26437,13 +26437,13 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
       "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-in-cwd/download/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-path-in-cwd/download/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
       "dev": true,
       "requires": {
@@ -26452,7 +26452,7 @@
     },
     "is-path-inside": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-path-inside/download/is-path-inside-2.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-path-inside/download/is-path-inside-2.1.0.tgz",
       "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
       "dev": true,
       "requires": {
@@ -26461,7 +26461,7 @@
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
@@ -26491,7 +26491,7 @@
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/is-resolvable/download/is-resolvable-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-resolvable/download/is-resolvable-1.1.0.tgz",
       "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
@@ -26503,7 +26503,7 @@
     },
     "is-svg": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/is-svg/download/is-svg-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/is-svg/download/is-svg-3.0.0.tgz",
       "integrity": "sha1-kyHb0pwhLlypnE+peUxxS8r6L3U=",
       "dev": true,
       "requires": {
@@ -26658,7 +26658,7 @@
     },
     "javascript-stringify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.taobao.org/javascript-stringify/download/javascript-stringify-2.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/javascript-stringify/download/javascript-stringify-2.0.1.tgz",
       "integrity": "sha1-bvNYA1MQ411mfGde1j0+t8GqGeU=",
       "dev": true
     },
@@ -26772,7 +26772,7 @@
     },
     "json3": {
       "version": "3.3.3",
-      "resolved": "https://registry.npm.taobao.org/json3/download/json3-3.3.3.tgz",
+      "resolved": "https://registry.npmmirror.com/json3/download/json3-3.3.3.tgz",
       "integrity": "sha1-f8EON1/FrkLEcFpcwKpvYr4wW4E=",
       "dev": true
     },
@@ -26824,7 +26824,7 @@
     },
     "killable": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/killable/download/killable-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/killable/download/killable-1.0.1.tgz",
       "integrity": "sha1-TIzkQRh6Bhx0dPuHygjipjgZSJI=",
       "dev": true
     },
@@ -26920,7 +26920,7 @@
     },
     "launch-editor-middleware": {
       "version": "2.2.1",
-      "resolved": "https://registry.npm.taobao.org/launch-editor-middleware/download/launch-editor-middleware-2.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/launch-editor-middleware/download/launch-editor-middleware-2.2.1.tgz",
       "integrity": "sha1-4UsH5scVSwpLhqD9NFeE5FgEwVc=",
       "dev": true,
       "requires": {
@@ -27141,13 +27141,13 @@
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
       "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
@@ -27159,13 +27159,13 @@
     },
     "lodash.transform": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.transform/download/lodash.transform-4.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.transform/download/lodash.transform-4.6.0.tgz",
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
     "lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
@@ -27186,7 +27186,7 @@
     },
     "loglevel": {
       "version": "1.7.1",
-      "resolved": "https://registry.npm.taobao.org/loglevel/download/loglevel-1.7.1.tgz?cache=0&sync_timestamp=1606314029553&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floglevel%2Fdownload%2Floglevel-1.7.1.tgz",
+      "resolved": "https://registry.npmmirror.com/loglevel/download/loglevel-1.7.1.tgz?cache=0&sync_timestamp=1606314029553&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floglevel%2Fdownload%2Floglevel-1.7.1.tgz",
       "integrity": "sha1-AF/eL15uRwaPk1/yhXPhJe9y8Zc=",
       "dev": true
     },
@@ -27210,7 +27210,7 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.taobao.org/lower-case/download/lower-case-1.1.4.tgz?cache=0&sync_timestamp=1606867292121&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flower-case%2Fdownload%2Flower-case-1.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/lower-case/download/lower-case-1.1.4.tgz?cache=0&sync_timestamp=1606867292121&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Flower-case%2Fdownload%2Flower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
@@ -27303,7 +27303,7 @@
     },
     "mdn-data": {
       "version": "2.0.4",
-      "resolved": "https://registry.npm.taobao.org/mdn-data/download/mdn-data-2.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/mdn-data/download/mdn-data-2.0.4.tgz",
       "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs=",
       "dev": true
     },
@@ -27356,7 +27356,7 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
@@ -27379,7 +27379,7 @@
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/merge-stream/download/merge-stream-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/merge-stream/download/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
@@ -27435,7 +27435,7 @@
     },
     "mime": {
       "version": "2.5.0",
-      "resolved": "https://registry.npm.taobao.org/mime/download/mime-2.5.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mime/download/mime-2.5.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-2.5.0.tgz",
       "integrity": "sha1-K0r5NEAXeYBu6YAmu0Lowa4YdrE=",
       "dev": true
     },
@@ -27465,7 +27465,7 @@
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
-      "resolved": "https://registry.npm.taobao.org/mini-css-extract-plugin/download/mini-css-extract-plugin-0.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mini-css-extract-plugin/download/mini-css-extract-plugin-0.9.0.tgz",
       "integrity": "sha1-R/LPB6oWWrNXM7H8l9TEbAVkM54=",
       "dev": true,
       "requires": {
@@ -27477,7 +27477,7 @@
       "dependencies": {
         "normalize-url": {
           "version": "1.9.1",
-          "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-1.9.1.tgz",
+          "resolved": "https://registry.npmmirror.com/normalize-url/download/normalize-url-1.9.1.tgz",
           "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
           "dev": true,
           "requires": {
@@ -27489,7 +27489,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -27538,7 +27538,7 @@
       "dependencies": {
         "yallist": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/yallist/download/yallist-4.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/yallist/download/yallist-4.0.0.tgz",
           "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
           "dev": true
         }
@@ -27914,7 +27914,7 @@
     },
     "multicast-dns": {
       "version": "6.2.3",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns/download/multicast-dns-6.2.3.tgz",
+      "resolved": "https://registry.npmmirror.com/multicast-dns/download/multicast-dns-6.2.3.tgz",
       "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
       "dev": true,
       "requires": {
@@ -27924,13 +27924,13 @@
     },
     "multicast-dns-service-types": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npm.taobao.org/mz/download/mz-2.7.0.tgz",
+      "resolved": "https://registry.npmmirror.com/mz/download/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "dev": true,
       "requires": {
@@ -28001,7 +28001,7 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "https://registry.npm.taobao.org/no-case/download/no-case-2.3.2.tgz?cache=0&sync_timestamp=1606867290260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fno-case%2Fdownload%2Fno-case-2.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/no-case/download/no-case-2.3.2.tgz?cache=0&sync_timestamp=1606867290260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fno-case%2Fdownload%2Fno-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
@@ -28043,7 +28043,7 @@
     },
     "node-forge": {
       "version": "0.10.0",
-      "resolved": "https://registry.npm.taobao.org/node-forge/download/node-forge-0.10.0.tgz?cache=0&sync_timestamp=1599010719234&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnode-forge%2Fdownload%2Fnode-forge-0.10.0.tgz",
+      "resolved": "https://registry.npmmirror.com/node-forge/download/node-forge-0.10.0.tgz?cache=0&sync_timestamp=1599010719234&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnode-forge%2Fdownload%2Fnode-forge-0.10.0.tgz",
       "integrity": "sha1-Mt6ir7Ppkm8C7lzoeUkCaRpna/M=",
       "dev": true
     },
@@ -28166,7 +28166,7 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/normalize-range/download/normalize-range-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/normalize-range/download/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
@@ -28199,7 +28199,7 @@
     },
     "nth-check": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/nth-check/download/nth-check-1.0.2.tgz?cache=0&sync_timestamp=1606860664533&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnth-check%2Fdownload%2Fnth-check-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/nth-check/download/nth-check-1.0.2.tgz?cache=0&sync_timestamp=1606860664533&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fnth-check%2Fdownload%2Fnth-check-1.0.2.tgz",
       "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
       "dev": true,
       "requires": {
@@ -28208,7 +28208,7 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://registry.npm.taobao.org/num2fraction/download/num2fraction-1.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/num2fraction/download/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
     },
@@ -28408,7 +28408,7 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/obuf/download/obuf-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/obuf/download/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
       "dev": true
     },
@@ -28422,7 +28422,7 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/on-headers/download/on-headers-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/on-headers/download/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
       "dev": true
     },
@@ -28459,13 +28459,13 @@
     },
     "opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npm.taobao.org/opener/download/opener-1.5.2.tgz",
+      "resolved": "https://registry.npmmirror.com/opener/download/opener-1.5.2.tgz",
       "integrity": "sha1-XTfh81B3udysQwE3InGv3rKhNZg=",
       "dev": true
     },
     "opn": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.taobao.org/opn/download/opn-5.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/opn/download/opn-5.5.0.tgz",
       "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
       "dev": true,
       "requires": {
@@ -28505,7 +28505,7 @@
     },
     "original": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/original/download/original-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/original/download/original-1.0.2.tgz",
       "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
       "dev": true,
       "requires": {
@@ -28562,7 +28562,7 @@
     },
     "p-retry": {
       "version": "3.0.1",
-      "resolved": "https://registry.npm.taobao.org/p-retry/download/p-retry-3.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/p-retry/download/p-retry-3.0.1.tgz",
       "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
       "dev": true,
       "requires": {
@@ -28646,7 +28646,7 @@
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.taobao.org/param-case/download/param-case-2.1.1.tgz?cache=0&sync_timestamp=1606867288643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparam-case%2Fdownload%2Fparam-case-2.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/param-case/download/param-case-2.1.1.tgz?cache=0&sync_timestamp=1606867288643&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparam-case%2Fdownload%2Fparam-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -28680,13 +28680,13 @@
     },
     "parse5": {
       "version": "5.1.1",
-      "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-5.1.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-5.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/parse5/download/parse5-5.1.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-5.1.1.tgz",
       "integrity": "sha1-9o5OW6GFKsLK3AD0VV//bCq7YXg=",
       "dev": true
     },
     "parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
-      "resolved": "https://registry.npm.taobao.org/parse5-htmlparser2-tree-adapter/download/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/parse5-htmlparser2-tree-adapter/download/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
       "integrity": "sha1-LN+a2CMyEUA3DU2/XT6Sx8jdxuY=",
       "dev": true,
       "requires": {
@@ -28695,7 +28695,7 @@
       "dependencies": {
         "parse5": {
           "version": "6.0.1",
-          "resolved": "https://registry.npm.taobao.org/parse5/download/parse5-6.0.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-6.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/parse5/download/parse5-6.0.1.tgz?cache=0&sync_timestamp=1595850971402&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fparse5%2Fdownload%2Fparse5-6.0.1.tgz",
           "integrity": "sha1-4aHAhcVps9wIMhGE8Zo5zCf3wws=",
           "dev": true
         }
@@ -28785,7 +28785,7 @@
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.taobao.org/path-is-inside/download/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/path-is-inside/download/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
@@ -28889,7 +28889,7 @@
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
-      "resolved": "https://registry.npm.taobao.org/pnp-webpack-plugin/download/pnp-webpack-plugin-1.6.4.tgz",
+      "resolved": "https://registry.npmmirror.com/pnp-webpack-plugin/download/pnp-webpack-plugin-1.6.4.tgz",
       "integrity": "sha1-yXEaxNxIpoXauvyG+Lbdn434QUk=",
       "dev": true,
       "requires": {
@@ -28898,7 +28898,7 @@
     },
     "portfinder": {
       "version": "1.0.28",
-      "resolved": "https://registry.npm.taobao.org/portfinder/download/portfinder-1.0.28.tgz",
+      "resolved": "https://registry.npmmirror.com/portfinder/download/portfinder-1.0.28.tgz",
       "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
       "dev": true,
       "requires": {
@@ -28909,7 +28909,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
           "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
           "dev": true,
           "requires": {
@@ -28937,13 +28937,13 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -28954,7 +28954,7 @@
     },
     "postcss-calc": {
       "version": "7.0.5",
-      "resolved": "https://registry.npm.taobao.org/postcss-calc/download/postcss-calc-7.0.5.tgz?cache=0&sync_timestamp=1609689190192&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-calc%2Fdownload%2Fpostcss-calc-7.0.5.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-calc/download/postcss-calc-7.0.5.tgz?cache=0&sync_timestamp=1609689190192&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-calc%2Fdownload%2Fpostcss-calc-7.0.5.tgz",
       "integrity": "sha1-+KbpnxLmGcLrwjz2xIb9wVhgkz4=",
       "dev": true,
       "requires": {
@@ -28965,7 +28965,7 @@
     },
     "postcss-colormin": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-colormin/download/postcss-colormin-4.0.3.tgz?cache=0&sync_timestamp=1612632637742&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-colormin%2Fdownload%2Fpostcss-colormin-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-colormin/download/postcss-colormin-4.0.3.tgz?cache=0&sync_timestamp=1612632637742&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-colormin%2Fdownload%2Fpostcss-colormin-4.0.3.tgz",
       "integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
       "dev": true,
       "requires": {
@@ -28978,7 +28978,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -28986,7 +28986,7 @@
     },
     "postcss-convert-values": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-convert-values/download/postcss-convert-values-4.0.1.tgz?cache=0&sync_timestamp=1612632638330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-convert-values%2Fdownload%2Fpostcss-convert-values-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-convert-values/download/postcss-convert-values-4.0.1.tgz?cache=0&sync_timestamp=1612632638330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-convert-values%2Fdownload%2Fpostcss-convert-values-4.0.1.tgz",
       "integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
       "dev": true,
       "requires": {
@@ -28996,7 +28996,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29004,7 +29004,7 @@
     },
     "postcss-discard-comments": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-comments/download/postcss-discard-comments-4.0.2.tgz?cache=0&sync_timestamp=1612632637618&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-comments%2Fdownload%2Fpostcss-discard-comments-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-comments/download/postcss-discard-comments-4.0.2.tgz?cache=0&sync_timestamp=1612632637618&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-comments%2Fdownload%2Fpostcss-discard-comments-4.0.2.tgz",
       "integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
       "dev": true,
       "requires": {
@@ -29013,7 +29013,7 @@
     },
     "postcss-discard-duplicates": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-duplicates/download/postcss-discard-duplicates-4.0.2.tgz?cache=0&sync_timestamp=1612632637567&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-duplicates%2Fdownload%2Fpostcss-discard-duplicates-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-duplicates/download/postcss-discard-duplicates-4.0.2.tgz?cache=0&sync_timestamp=1612632637567&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-duplicates%2Fdownload%2Fpostcss-discard-duplicates-4.0.2.tgz",
       "integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
       "dev": true,
       "requires": {
@@ -29022,7 +29022,7 @@
     },
     "postcss-discard-empty": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-empty/download/postcss-discard-empty-4.0.1.tgz?cache=0&sync_timestamp=1612632638357&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-empty%2Fdownload%2Fpostcss-discard-empty-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-empty/download/postcss-discard-empty-4.0.1.tgz?cache=0&sync_timestamp=1612632638357&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-empty%2Fdownload%2Fpostcss-discard-empty-4.0.1.tgz",
       "integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
       "dev": true,
       "requires": {
@@ -29031,7 +29031,7 @@
     },
     "postcss-discard-overridden": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-discard-overridden/download/postcss-discard-overridden-4.0.1.tgz?cache=0&sync_timestamp=1612632637686&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-overridden%2Fdownload%2Fpostcss-discard-overridden-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-discard-overridden/download/postcss-discard-overridden-4.0.1.tgz?cache=0&sync_timestamp=1612632637686&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-discard-overridden%2Fdownload%2Fpostcss-discard-overridden-4.0.1.tgz",
       "integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
       "dev": true,
       "requires": {
@@ -29040,7 +29040,7 @@
     },
     "postcss-load-config": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-load-config/download/postcss-load-config-2.1.2.tgz?cache=0&sync_timestamp=1612743037145&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-load-config%2Fdownload%2Fpostcss-load-config-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-load-config/download/postcss-load-config-2.1.2.tgz?cache=0&sync_timestamp=1612743037145&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-load-config%2Fdownload%2Fpostcss-load-config-2.1.2.tgz",
       "integrity": "sha1-xepQTyxK7zPHNZo03jVzdyrXUCo=",
       "dev": true,
       "requires": {
@@ -29050,7 +29050,7 @@
     },
     "postcss-loader": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-loader/download/postcss-loader-3.0.0.tgz?cache=0&sync_timestamp=1612277661855&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-loader%2Fdownload%2Fpostcss-loader-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-loader/download/postcss-loader-3.0.0.tgz?cache=0&sync_timestamp=1612277661855&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-loader%2Fdownload%2Fpostcss-loader-3.0.0.tgz",
       "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
       "dev": true,
       "requires": {
@@ -29062,7 +29062,7 @@
       "dependencies": {
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -29075,7 +29075,7 @@
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
-      "resolved": "https://registry.npm.taobao.org/postcss-merge-longhand/download/postcss-merge-longhand-4.0.11.tgz?cache=0&sync_timestamp=1612632638851&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-longhand%2Fdownload%2Fpostcss-merge-longhand-4.0.11.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-merge-longhand/download/postcss-merge-longhand-4.0.11.tgz?cache=0&sync_timestamp=1612632638851&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-longhand%2Fdownload%2Fpostcss-merge-longhand-4.0.11.tgz",
       "integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
       "dev": true,
       "requires": {
@@ -29087,7 +29087,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29095,7 +29095,7 @@
     },
     "postcss-merge-rules": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-merge-rules/download/postcss-merge-rules-4.0.3.tgz?cache=0&sync_timestamp=1612632638899&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-rules%2Fdownload%2Fpostcss-merge-rules-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-merge-rules/download/postcss-merge-rules-4.0.3.tgz?cache=0&sync_timestamp=1612632638899&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-merge-rules%2Fdownload%2Fpostcss-merge-rules-4.0.3.tgz",
       "integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
       "dev": true,
       "requires": {
@@ -29109,7 +29109,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.2",
-          "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
           "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
           "dev": true,
           "requires": {
@@ -29122,7 +29122,7 @@
     },
     "postcss-minify-font-values": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-font-values/download/postcss-minify-font-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640444&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-font-values%2Fdownload%2Fpostcss-minify-font-values-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-font-values/download/postcss-minify-font-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640444&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-font-values%2Fdownload%2Fpostcss-minify-font-values-4.0.2.tgz",
       "integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
       "dev": true,
       "requires": {
@@ -29132,7 +29132,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29140,7 +29140,7 @@
     },
     "postcss-minify-gradients": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-gradients/download/postcss-minify-gradients-4.0.2.tgz?cache=0&sync_timestamp=1612632640506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-gradients%2Fdownload%2Fpostcss-minify-gradients-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-gradients/download/postcss-minify-gradients-4.0.2.tgz?cache=0&sync_timestamp=1612632640506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-gradients%2Fdownload%2Fpostcss-minify-gradients-4.0.2.tgz",
       "integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
       "dev": true,
       "requires": {
@@ -29152,7 +29152,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29160,7 +29160,7 @@
     },
     "postcss-minify-params": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-params/download/postcss-minify-params-4.0.2.tgz?cache=0&sync_timestamp=1612632640705&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-params%2Fdownload%2Fpostcss-minify-params-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-params/download/postcss-minify-params-4.0.2.tgz?cache=0&sync_timestamp=1612632640705&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-params%2Fdownload%2Fpostcss-minify-params-4.0.2.tgz",
       "integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
       "dev": true,
       "requires": {
@@ -29174,7 +29174,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29182,7 +29182,7 @@
     },
     "postcss-minify-selectors": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-minify-selectors/download/postcss-minify-selectors-4.0.2.tgz?cache=0&sync_timestamp=1612632640495&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-selectors%2Fdownload%2Fpostcss-minify-selectors-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-minify-selectors/download/postcss-minify-selectors-4.0.2.tgz?cache=0&sync_timestamp=1612632640495&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-minify-selectors%2Fdownload%2Fpostcss-minify-selectors-4.0.2.tgz",
       "integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
       "dev": true,
       "requires": {
@@ -29194,7 +29194,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.2",
-          "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
           "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
           "dev": true,
           "requires": {
@@ -29207,7 +29207,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-extract-imports/download/postcss-modules-extract-imports-2.0.0.tgz?cache=0&sync_timestamp=1602588202058&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-extract-imports%2Fdownload%2Fpostcss-modules-extract-imports-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-extract-imports/download/postcss-modules-extract-imports-2.0.0.tgz?cache=0&sync_timestamp=1602588202058&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-extract-imports%2Fdownload%2Fpostcss-modules-extract-imports-2.0.0.tgz",
       "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
       "dev": true,
       "requires": {
@@ -29216,7 +29216,7 @@
     },
     "postcss-modules-local-by-default": {
       "version": "3.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-local-by-default/download/postcss-modules-local-by-default-3.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-local-by-default/download/postcss-modules-local-by-default-3.0.3.tgz",
       "integrity": "sha1-uxTgzHgnnVBNvcv9fgyiiZP/u7A=",
       "dev": true,
       "requires": {
@@ -29228,7 +29228,7 @@
     },
     "postcss-modules-scope": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-scope/download/postcss-modules-scope-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-scope/download/postcss-modules-scope-2.2.0.tgz",
       "integrity": "sha1-OFyuATzHdD9afXYC0Qc6iequYu4=",
       "dev": true,
       "requires": {
@@ -29238,7 +29238,7 @@
     },
     "postcss-modules-values": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-modules-values/download/postcss-modules-values-3.0.0.tgz?cache=0&sync_timestamp=1602586308035&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-values%2Fdownload%2Fpostcss-modules-values-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-modules-values/download/postcss-modules-values-3.0.0.tgz?cache=0&sync_timestamp=1602586308035&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-modules-values%2Fdownload%2Fpostcss-modules-values-3.0.0.tgz",
       "integrity": "sha1-W1AA1uuuKbQlUwG0o6VFdEI+fxA=",
       "dev": true,
       "requires": {
@@ -29248,7 +29248,7 @@
     },
     "postcss-normalize-charset": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-charset/download/postcss-normalize-charset-4.0.1.tgz?cache=0&sync_timestamp=1612632640617&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-charset%2Fdownload%2Fpostcss-normalize-charset-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-charset/download/postcss-normalize-charset-4.0.1.tgz?cache=0&sync_timestamp=1612632640617&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-charset%2Fdownload%2Fpostcss-normalize-charset-4.0.1.tgz",
       "integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
       "dev": true,
       "requires": {
@@ -29257,7 +29257,7 @@
     },
     "postcss-normalize-display-values": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-display-values/download/postcss-normalize-display-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640538&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-display-values%2Fdownload%2Fpostcss-normalize-display-values-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-display-values/download/postcss-normalize-display-values-4.0.2.tgz?cache=0&sync_timestamp=1612632640538&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-display-values%2Fdownload%2Fpostcss-normalize-display-values-4.0.2.tgz",
       "integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
       "dev": true,
       "requires": {
@@ -29268,7 +29268,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29276,7 +29276,7 @@
     },
     "postcss-normalize-positions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-positions/download/postcss-normalize-positions-4.0.2.tgz?cache=0&sync_timestamp=1612632640517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-positions%2Fdownload%2Fpostcss-normalize-positions-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-positions/download/postcss-normalize-positions-4.0.2.tgz?cache=0&sync_timestamp=1612632640517&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-positions%2Fdownload%2Fpostcss-normalize-positions-4.0.2.tgz",
       "integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
       "dev": true,
       "requires": {
@@ -29288,7 +29288,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29296,7 +29296,7 @@
     },
     "postcss-normalize-repeat-style": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-repeat-style/download/postcss-normalize-repeat-style-4.0.2.tgz?cache=0&sync_timestamp=1612632640701&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-repeat-style%2Fdownload%2Fpostcss-normalize-repeat-style-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-repeat-style/download/postcss-normalize-repeat-style-4.0.2.tgz?cache=0&sync_timestamp=1612632640701&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-repeat-style%2Fdownload%2Fpostcss-normalize-repeat-style-4.0.2.tgz",
       "integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
       "dev": true,
       "requires": {
@@ -29308,7 +29308,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29316,7 +29316,7 @@
     },
     "postcss-normalize-string": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-string/download/postcss-normalize-string-4.0.2.tgz?cache=0&sync_timestamp=1612632640644&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-string%2Fdownload%2Fpostcss-normalize-string-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-string/download/postcss-normalize-string-4.0.2.tgz?cache=0&sync_timestamp=1612632640644&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-string%2Fdownload%2Fpostcss-normalize-string-4.0.2.tgz",
       "integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
       "dev": true,
       "requires": {
@@ -29327,7 +29327,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29335,7 +29335,7 @@
     },
     "postcss-normalize-timing-functions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-timing-functions/download/postcss-normalize-timing-functions-4.0.2.tgz?cache=0&sync_timestamp=1612632641797&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-timing-functions%2Fdownload%2Fpostcss-normalize-timing-functions-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-timing-functions/download/postcss-normalize-timing-functions-4.0.2.tgz?cache=0&sync_timestamp=1612632641797&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-timing-functions%2Fdownload%2Fpostcss-normalize-timing-functions-4.0.2.tgz",
       "integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
       "dev": true,
       "requires": {
@@ -29346,7 +29346,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29354,7 +29354,7 @@
     },
     "postcss-normalize-unicode": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-unicode/download/postcss-normalize-unicode-4.0.1.tgz?cache=0&sync_timestamp=1612632641502&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-unicode%2Fdownload%2Fpostcss-normalize-unicode-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-unicode/download/postcss-normalize-unicode-4.0.1.tgz?cache=0&sync_timestamp=1612632641502&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-unicode%2Fdownload%2Fpostcss-normalize-unicode-4.0.1.tgz",
       "integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
       "dev": true,
       "requires": {
@@ -29365,7 +29365,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29373,7 +29373,7 @@
     },
     "postcss-normalize-url": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-url/download/postcss-normalize-url-4.0.1.tgz?cache=0&sync_timestamp=1612632641883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-url%2Fdownload%2Fpostcss-normalize-url-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-url/download/postcss-normalize-url-4.0.1.tgz?cache=0&sync_timestamp=1612632641883&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-url%2Fdownload%2Fpostcss-normalize-url-4.0.1.tgz",
       "integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
       "dev": true,
       "requires": {
@@ -29385,13 +29385,13 @@
       "dependencies": {
         "normalize-url": {
           "version": "3.3.0",
-          "resolved": "https://registry.npm.taobao.org/normalize-url/download/normalize-url-3.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/normalize-url/download/normalize-url-3.3.0.tgz",
           "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
           "dev": true
         },
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29399,7 +29399,7 @@
     },
     "postcss-normalize-whitespace": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-normalize-whitespace/download/postcss-normalize-whitespace-4.0.2.tgz?cache=0&sync_timestamp=1612632641822&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-whitespace%2Fdownload%2Fpostcss-normalize-whitespace-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-normalize-whitespace/download/postcss-normalize-whitespace-4.0.2.tgz?cache=0&sync_timestamp=1612632641822&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-normalize-whitespace%2Fdownload%2Fpostcss-normalize-whitespace-4.0.2.tgz",
       "integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
       "dev": true,
       "requires": {
@@ -29409,7 +29409,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29417,7 +29417,7 @@
     },
     "postcss-ordered-values": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-ordered-values/download/postcss-ordered-values-4.1.2.tgz?cache=0&sync_timestamp=1612632651029&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-ordered-values%2Fdownload%2Fpostcss-ordered-values-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-ordered-values/download/postcss-ordered-values-4.1.2.tgz?cache=0&sync_timestamp=1612632651029&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-ordered-values%2Fdownload%2Fpostcss-ordered-values-4.1.2.tgz",
       "integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
       "dev": true,
       "requires": {
@@ -29428,7 +29428,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29436,7 +29436,7 @@
     },
     "postcss-reduce-initial": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/postcss-reduce-initial/download/postcss-reduce-initial-4.0.3.tgz?cache=0&sync_timestamp=1612632642629&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-initial%2Fdownload%2Fpostcss-reduce-initial-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-reduce-initial/download/postcss-reduce-initial-4.0.3.tgz?cache=0&sync_timestamp=1612632642629&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-initial%2Fdownload%2Fpostcss-reduce-initial-4.0.3.tgz",
       "integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
       "dev": true,
       "requires": {
@@ -29448,7 +29448,7 @@
     },
     "postcss-reduce-transforms": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-reduce-transforms/download/postcss-reduce-transforms-4.0.2.tgz?cache=0&sync_timestamp=1612632643250&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-transforms%2Fdownload%2Fpostcss-reduce-transforms-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-reduce-transforms/download/postcss-reduce-transforms-4.0.2.tgz?cache=0&sync_timestamp=1612632643250&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-reduce-transforms%2Fdownload%2Fpostcss-reduce-transforms-4.0.2.tgz",
       "integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
       "dev": true,
       "requires": {
@@ -29460,7 +29460,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29468,7 +29468,7 @@
     },
     "postcss-selector-parser": {
       "version": "6.0.4",
-      "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-6.0.4.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-6.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-6.0.4.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-6.0.4.tgz",
       "integrity": "sha1-VgdaE4CgRgTDiwY+p3Z6Epr1wrM=",
       "dev": true,
       "requires": {
@@ -29480,7 +29480,7 @@
     },
     "postcss-svgo": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/postcss-svgo/download/postcss-svgo-4.0.2.tgz?cache=0&sync_timestamp=1612632644074&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-svgo%2Fdownload%2Fpostcss-svgo-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-svgo/download/postcss-svgo-4.0.2.tgz?cache=0&sync_timestamp=1612632644074&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-svgo%2Fdownload%2Fpostcss-svgo-4.0.2.tgz",
       "integrity": "sha1-F7mXvHEbMzurFDqu07jT1uPTglg=",
       "dev": true,
       "requires": {
@@ -29492,7 +29492,7 @@
       "dependencies": {
         "postcss-value-parser": {
           "version": "3.3.1",
-          "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
           "dev": true
         }
@@ -29500,7 +29500,7 @@
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
-      "resolved": "https://registry.npm.taobao.org/postcss-unique-selectors/download/postcss-unique-selectors-4.0.1.tgz?cache=0&sync_timestamp=1612632644958&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-unique-selectors%2Fdownload%2Fpostcss-unique-selectors-4.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-unique-selectors/download/postcss-unique-selectors-4.0.1.tgz?cache=0&sync_timestamp=1612632644958&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-unique-selectors%2Fdownload%2Fpostcss-unique-selectors-4.0.1.tgz",
       "integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
       "dev": true,
       "requires": {
@@ -29511,19 +29511,19 @@
     },
     "postcss-value-parser": {
       "version": "4.1.0",
-      "resolved": "https://registry.npm.taobao.org/postcss-value-parser/download/postcss-value-parser-4.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/postcss-value-parser/download/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/prepend-http/download/prepend-http-1.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/prepend-http/download/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "prettier": {
       "version": "1.19.1",
-      "resolved": "https://registry.npm.taobao.org/prettier/download/prettier-1.19.1.tgz",
+      "resolved": "https://registry.npmmirror.com/prettier/download/prettier-1.19.1.tgz",
       "integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
       "dev": true,
       "optional": true
@@ -29536,7 +29536,7 @@
     },
     "pretty-error": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.taobao.org/pretty-error/download/pretty-error-2.1.2.tgz?cache=0&sync_timestamp=1609589422297&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-error%2Fdownload%2Fpretty-error-2.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/pretty-error/download/pretty-error-2.1.2.tgz?cache=0&sync_timestamp=1609589422297&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpretty-error%2Fdownload%2Fpretty-error-2.1.2.tgz",
       "integrity": "sha1-von4LYGxyG7I/fvDhQRYgnJ/k7Y=",
       "dev": true,
       "requires": {
@@ -29581,7 +29581,7 @@
     },
     "proxy-addr": {
       "version": "2.0.6",
-      "resolved": "https://registry.npm.taobao.org/proxy-addr/download/proxy-addr-2.0.6.tgz",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/download/proxy-addr-2.0.6.tgz",
       "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
       "dev": true,
       "requires": {
@@ -29673,7 +29673,7 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "https://registry.npm.taobao.org/q/download/q-1.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/q/download/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
@@ -29685,7 +29685,7 @@
     },
     "query-string": {
       "version": "4.3.4",
-      "resolved": "https://registry.npm.taobao.org/query-string/download/query-string-4.3.4.tgz?cache=0&sync_timestamp=1612938230404&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquery-string%2Fdownload%2Fquery-string-4.3.4.tgz",
+      "resolved": "https://registry.npmmirror.com/query-string/download/query-string-4.3.4.tgz?cache=0&sync_timestamp=1612938230404&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquery-string%2Fdownload%2Fquery-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "dev": true,
       "requires": {
@@ -29707,7 +29707,7 @@
     },
     "querystringify": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.taobao.org/querystringify/download/querystringify-2.2.0.tgz?cache=0&sync_timestamp=1597687052330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquerystringify%2Fdownload%2Fquerystringify-2.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/querystringify/download/querystringify-2.2.0.tgz?cache=0&sync_timestamp=1597687052330&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fquerystringify%2Fdownload%2Fquerystringify-2.2.0.tgz",
       "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
       "dev": true
     },
@@ -29737,7 +29737,7 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npm.taobao.org/range-parser/download/range-parser-1.2.1.tgz",
+      "resolved": "https://registry.npmmirror.com/range-parser/download/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "dev": true
     },
@@ -29754,7 +29754,7 @@
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "https://registry.npm.taobao.org/raw-body/download/raw-body-2.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/raw-body/download/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "dev": true,
       "requires": {
@@ -29766,7 +29766,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.7.2",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.2.tgz",
+          "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.7.2.tgz",
           "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
           "dev": true,
           "requires": {
@@ -29779,13 +29779,13 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
           "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
           "dev": true
         }
@@ -29941,7 +29941,7 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "https://registry.npm.taobao.org/relateurl/download/relateurl-0.2.7.tgz",
+      "resolved": "https://registry.npmmirror.com/relateurl/download/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
@@ -30090,7 +30090,7 @@
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/requires-port/download/requires-port-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/requires-port/download/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
@@ -30112,7 +30112,7 @@
     },
     "resolve-cwd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
@@ -30121,7 +30121,7 @@
     },
     "resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/resolve-from/download/resolve-from-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/resolve-from/download/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true
     },
@@ -30157,19 +30157,19 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://registry.npm.taobao.org/retry/download/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmmirror.com/retry/download/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
     "rgb-regex": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/rgb-regex/download/rgb-regex-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/rgb-regex/download/rgb-regex-1.0.1.tgz",
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
       "dev": true
     },
     "rgba-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/rgba-regex/download/rgba-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/rgba-regex/download/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
       "dev": true
     },
@@ -30297,7 +30297,7 @@
     },
     "sass": {
       "version": "1.32.7",
-      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.32.7.tgz",
+      "resolved": "https://registry.npmmirror.com/sass/download/sass-1.32.7.tgz",
       "integrity": "sha1-Yyqd8rhdxLNGl3/K8tXm8rcDn9g=",
       "dev": true,
       "requires": {
@@ -30343,13 +30343,13 @@
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/select-hose/download/select-hose-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/select-hose/download/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "selfsigned": {
       "version": "1.10.8",
-      "resolved": "https://registry.npm.taobao.org/selfsigned/download/selfsigned-1.10.8.tgz?cache=0&sync_timestamp=1600187989135&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fselfsigned%2Fdownload%2Fselfsigned-1.10.8.tgz",
+      "resolved": "https://registry.npmmirror.com/selfsigned/download/selfsigned-1.10.8.tgz?cache=0&sync_timestamp=1600187989135&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fselfsigned%2Fdownload%2Fselfsigned-1.10.8.tgz",
       "integrity": "sha1-DRcgi30Swz+OrIXEGDXyf8PYGjA=",
       "dev": true,
       "requires": {
@@ -30364,7 +30364,7 @@
     },
     "send": {
       "version": "0.17.1",
-      "resolved": "https://registry.npm.taobao.org/send/download/send-0.17.1.tgz",
+      "resolved": "https://registry.npmmirror.com/send/download/send-0.17.1.tgz",
       "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
       "dev": true,
       "requires": {
@@ -30385,7 +30385,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -30394,7 +30394,7 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+              "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
@@ -30402,7 +30402,7 @@
         },
         "http-errors": {
           "version": "1.7.3",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.7.3.tgz",
+          "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.7.3.tgz",
           "integrity": "sha1-bGGeT5xgMIw4UZSYwU+7EKrOuwY=",
           "dev": true,
           "requires": {
@@ -30415,19 +30415,19 @@
         },
         "mime": {
           "version": "1.6.0",
-          "resolved": "https://registry.npm.taobao.org/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
+          "resolved": "https://registry.npmmirror.com/mime/download/mime-1.6.0.tgz?cache=0&sync_timestamp=1610756280096&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmime%2Fdownload%2Fmime-1.6.0.tgz",
           "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
           "dev": true
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.1.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.1.1.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.1.tgz",
           "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
           "dev": true
         }
@@ -30444,7 +30444,7 @@
     },
     "serve-index": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/serve-index/download/serve-index-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/serve-index/download/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "dev": true,
       "requires": {
@@ -30459,7 +30459,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-2.6.9.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -30468,7 +30468,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "https://registry.npm.taobao.org/http-errors/download/http-errors-1.6.3.tgz",
+          "resolved": "https://registry.npmmirror.com/http-errors/download/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -30480,19 +30480,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
+          "resolved": "https://registry.npmmirror.com/inherits/download/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433872491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "https://registry.npm.taobao.org/setprototypeof/download/setprototypeof-1.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/setprototypeof/download/setprototypeof-1.1.0.tgz",
           "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
           "dev": true
         }
@@ -30500,7 +30500,7 @@
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "https://registry.npm.taobao.org/serve-static/download/serve-static-1.14.1.tgz",
+      "resolved": "https://registry.npmmirror.com/serve-static/download/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "dev": true,
       "requires": {
@@ -30852,7 +30852,7 @@
     },
     "sockjs": {
       "version": "0.3.21",
-      "resolved": "https://registry.npm.taobao.org/sockjs/download/sockjs-0.3.21.tgz",
+      "resolved": "https://registry.npmmirror.com/sockjs/download/sockjs-0.3.21.tgz",
       "integrity": "sha1-s0/7mOeWkwtgoM+hGQTWozmn1Bc=",
       "dev": true,
       "requires": {
@@ -30863,7 +30863,7 @@
     },
     "sockjs-client": {
       "version": "1.5.0",
-      "resolved": "https://registry.npm.taobao.org/sockjs-client/download/sockjs-client-1.5.0.tgz",
+      "resolved": "https://registry.npmmirror.com/sockjs-client/download/sockjs-client-1.5.0.tgz",
       "integrity": "sha1-L4/11LZZ4NCS96ugt8OGvSqiCt0=",
       "dev": true,
       "requires": {
@@ -30877,7 +30877,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.7",
-          "resolved": "https://registry.npm.taobao.org/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
+          "resolved": "https://registry.npmmirror.com/debug/download/debug-3.2.7.tgz?cache=0&sync_timestamp=1607566571506&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebug%2Fdownload%2Fdebug-3.2.7.tgz",
           "integrity": "sha1-clgLfpFF+zm2Z2+cXl+xALk0F5o=",
           "dev": true,
           "requires": {
@@ -30888,7 +30888,7 @@
     },
     "sort-keys": {
       "version": "1.1.2",
-      "resolved": "https://registry.npm.taobao.org/sort-keys/download/sort-keys-1.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsort-keys%2Fdownload%2Fsort-keys-1.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/sort-keys/download/sort-keys-1.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsort-keys%2Fdownload%2Fsort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
@@ -31009,7 +31009,7 @@
     },
     "spdy": {
       "version": "4.0.2",
-      "resolved": "https://registry.npm.taobao.org/spdy/download/spdy-4.0.2.tgz",
+      "resolved": "https://registry.npmmirror.com/spdy/download/spdy-4.0.2.tgz",
       "integrity": "sha1-t09GYgOj7aRSwCSSuR+56EonZ3s=",
       "dev": true,
       "requires": {
@@ -31022,7 +31022,7 @@
     },
     "spdy-transport": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.taobao.org/spdy-transport/download/spdy-transport-3.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/spdy-transport/download/spdy-transport-3.0.0.tgz",
       "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
       "dev": true,
       "requires": {
@@ -31077,13 +31077,13 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "https://registry.npm.taobao.org/stable/download/stable-0.1.8.tgz",
+      "resolved": "https://registry.npmmirror.com/stable/download/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
     "stackframe": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/stackframe/download/stackframe-1.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/stackframe/download/stackframe-1.2.0.tgz",
       "integrity": "sha1-UkKUktY8YuuYmATBFVLj0i53kwM=",
       "dev": true
     },
@@ -31274,7 +31274,7 @@
     },
     "strict-uri-encode": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
@@ -31422,7 +31422,7 @@
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/strip-final-newline/download/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/strip-final-newline/download/strip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true
     },
@@ -31434,7 +31434,7 @@
     },
     "stylehacks": {
       "version": "4.0.3",
-      "resolved": "https://registry.npm.taobao.org/stylehacks/download/stylehacks-4.0.3.tgz?cache=0&sync_timestamp=1612632646142&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstylehacks%2Fdownload%2Fstylehacks-4.0.3.tgz",
+      "resolved": "https://registry.npmmirror.com/stylehacks/download/stylehacks-4.0.3.tgz?cache=0&sync_timestamp=1612632646142&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fstylehacks%2Fdownload%2Fstylehacks-4.0.3.tgz",
       "integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
       "dev": true,
       "requires": {
@@ -31445,7 +31445,7 @@
       "dependencies": {
         "postcss-selector-parser": {
           "version": "3.1.2",
-          "resolved": "https://registry.npm.taobao.org/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
+          "resolved": "https://registry.npmmirror.com/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz?cache=0&sync_timestamp=1601045450967&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fpostcss-selector-parser%2Fdownload%2Fpostcss-selector-parser-3.1.2.tgz",
           "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
           "dev": true,
           "requires": {
@@ -31492,7 +31492,7 @@
     },
     "svgo": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.taobao.org/svgo/download/svgo-1.3.2.tgz",
+      "resolved": "https://registry.npmmirror.com/svgo/download/svgo-1.3.2.tgz",
       "integrity": "sha1-ttxRHAYzRsnkFbgeQ0ARRbltQWc=",
       "dev": true,
       "requires": {
@@ -31618,7 +31618,7 @@
     },
     "thenify": {
       "version": "3.3.1",
-      "resolved": "https://registry.npm.taobao.org/thenify/download/thenify-3.3.1.tgz",
+      "resolved": "https://registry.npmmirror.com/thenify/download/thenify-3.3.1.tgz",
       "integrity": "sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=",
       "dev": true,
       "requires": {
@@ -31627,7 +31627,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.taobao.org/thenify-all/download/thenify-all-1.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/thenify-all/download/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
@@ -31694,7 +31694,7 @@
     },
     "thunky": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.taobao.org/thunky/download/thunky-1.1.0.tgz",
+      "resolved": "https://registry.npmmirror.com/thunky/download/thunky-1.1.0.tgz",
       "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
       "dev": true
     },
@@ -31709,7 +31709,7 @@
     },
     "timsort": {
       "version": "0.3.0",
-      "resolved": "https://registry.npm.taobao.org/timsort/download/timsort-0.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/timsort/download/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
@@ -31784,7 +31784,7 @@
     },
     "toposort": {
       "version": "1.0.7",
-      "resolved": "https://registry.npm.taobao.org/toposort/download/toposort-1.0.7.tgz",
+      "resolved": "https://registry.npmmirror.com/toposort/download/toposort-1.0.7.tgz",
       "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
       "dev": true
     },
@@ -31809,7 +31809,7 @@
     },
     "tryer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/tryer/download/tryer-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/tryer/download/tryer-1.0.1.tgz",
       "integrity": "sha1-8shUBoALmw90yfdGW4HqrSQSUvg=",
       "dev": true
     },
@@ -31828,7 +31828,7 @@
     },
     "ts-pnp": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.taobao.org/ts-pnp/download/ts-pnp-1.2.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ts-pnp/download/ts-pnp-1.2.0.tgz",
       "integrity": "sha1-pQCtCEsHmPHDBxrzkeZZEshrypI=",
       "dev": true
     },
@@ -31898,7 +31898,7 @@
     },
     "uglify-js": {
       "version": "3.4.10",
-      "resolved": "https://registry.npm.taobao.org/uglify-js/download/uglify-js-3.4.10.tgz?cache=0&sync_timestamp=1613235170039&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuglify-js%2Fdownload%2Fuglify-js-3.4.10.tgz",
+      "resolved": "https://registry.npmmirror.com/uglify-js/download/uglify-js-3.4.10.tgz?cache=0&sync_timestamp=1613235170039&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fuglify-js%2Fdownload%2Fuglify-js-3.4.10.tgz",
       "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
       "dev": true,
       "requires": {
@@ -31908,13 +31908,13 @@
       "dependencies": {
         "commander": {
           "version": "2.19.0",
-          "resolved": "https://registry.npm.taobao.org/commander/download/commander-2.19.0.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.19.0.tgz",
+          "resolved": "https://registry.npmmirror.com/commander/download/commander-2.19.0.tgz?cache=0&sync_timestamp=1610702173050&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcommander%2Fdownload%2Fcommander-2.19.0.tgz",
           "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
           "dev": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmmirror.com/source-map/download/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -31962,13 +31962,13 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/uniq/download/uniq-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/uniq/download/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.taobao.org/uniqs/download/uniqs-2.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/uniqs/download/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
@@ -32007,13 +32007,13 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/unpipe/download/unpipe-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/unpipe/download/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unquote": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.taobao.org/unquote/download/unquote-1.1.1.tgz",
+      "resolved": "https://registry.npmmirror.com/unquote/download/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
       "dev": true
     },
@@ -32071,7 +32071,7 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.taobao.org/upper-case/download/upper-case-1.1.3.tgz",
+      "resolved": "https://registry.npmmirror.com/upper-case/download/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
@@ -32115,7 +32115,7 @@
     },
     "url-loader": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.taobao.org/url-loader/download/url-loader-2.3.0.tgz?cache=0&sync_timestamp=1602252665628&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Furl-loader%2Fdownload%2Furl-loader-2.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/url-loader/download/url-loader-2.3.0.tgz?cache=0&sync_timestamp=1602252665628&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Furl-loader%2Fdownload%2Furl-loader-2.3.0.tgz",
       "integrity": "sha1-4OLvZY8APvuMpBsPP/v3a6uIZYs=",
       "dev": true,
       "requires": {
@@ -32164,7 +32164,7 @@
     },
     "util.promisify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.taobao.org/util.promisify/download/util.promisify-1.0.0.tgz?cache=0&sync_timestamp=1610159866228&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil.promisify%2Fdownload%2Futil.promisify-1.0.0.tgz",
+      "resolved": "https://registry.npmmirror.com/util.promisify/download/util.promisify-1.0.0.tgz?cache=0&sync_timestamp=1610159866228&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Futil.promisify%2Fdownload%2Futil.promisify-1.0.0.tgz",
       "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
       "dev": true,
       "requires": {
@@ -32174,7 +32174,7 @@
     },
     "utila": {
       "version": "0.4.0",
-      "resolved": "https://registry.npm.taobao.org/utila/download/utila-0.4.0.tgz",
+      "resolved": "https://registry.npmmirror.com/utila/download/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
       "dev": true
     },
@@ -32185,7 +32185,7 @@
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.taobao.org/utils-merge/download/utils-merge-1.0.1.tgz",
+      "resolved": "https://registry.npmmirror.com/utils-merge/download/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
@@ -32235,7 +32235,7 @@
     },
     "vendors": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.taobao.org/vendors/download/vendors-1.0.4.tgz",
+      "resolved": "https://registry.npmmirror.com/vendors/download/vendors-1.0.4.tgz",
       "integrity": "sha1-4rgApT56Kbk1BsPPQRANFsTErY4=",
       "dev": true
     },
@@ -32275,7 +32275,7 @@
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",
-      "resolved": "https://registry.npm.taobao.org/vue-hot-reload-api/download/vue-hot-reload-api-2.3.4.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-hot-reload-api/download/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha1-UylVzB6yCKPZkLOp+acFdGV+CPI=",
       "dev": true
     },
@@ -32290,7 +32290,7 @@
     },
     "vue-loader": {
       "version": "15.9.6",
-      "resolved": "https://registry.npm.taobao.org/vue-loader/download/vue-loader-15.9.6.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-15.9.6.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-loader/download/vue-loader-15.9.6.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-15.9.6.tgz",
       "integrity": "sha1-9Lua4gw6g3CvPs8JuBJtOP/ba4s=",
       "dev": true,
       "requires": {
@@ -32303,7 +32303,7 @@
       "dependencies": {
         "hash-sum": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
@@ -32311,7 +32311,7 @@
     },
     "vue-loader-v16": {
       "version": "npm:vue-loader@16.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-loader/download/vue-loader-16.1.2.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-16.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-loader/download/vue-loader-16.1.2.tgz?cache=0&sync_timestamp=1608187947155&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fvue-loader%2Fdownload%2Fvue-loader-16.1.2.tgz",
       "integrity": "sha1-XAO2xQ0qX5g8fOuhXFDXjKKymPQ=",
       "dev": true,
       "optional": true,
@@ -32323,7 +32323,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://registry.npm.taobao.org/ansi-styles/download/ansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/ansi-styles/download/ansi-styles-4.3.0.tgz",
           "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "optional": true,
@@ -32333,7 +32333,7 @@
         },
         "chalk": {
           "version": "4.1.0",
-          "resolved": "https://registry.npm.taobao.org/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/chalk/download/chalk-4.1.0.tgz?cache=0&sync_timestamp=1592843133653&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchalk%2Fdownload%2Fchalk-4.1.0.tgz",
           "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
           "dev": true,
           "optional": true,
@@ -32344,7 +32344,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://registry.npm.taobao.org/color-convert/download/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/color-convert/download/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "optional": true,
@@ -32354,21 +32354,21 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://registry.npm.taobao.org/color-name/download/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmmirror.com/color-name/download/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true,
           "optional": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/has-flag/download/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true,
           "optional": true
         },
         "loader-utils": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/loader-utils/download/loader-utils-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/loader-utils/download/loader-utils-2.0.0.tgz",
           "integrity": "sha1-5MrOW4FtQloWa18JfhDNErNgZLA=",
           "dev": true,
           "optional": true,
@@ -32380,7 +32380,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-7.2.0.tgz",
           "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "optional": true,
@@ -32458,7 +32458,7 @@
     },
     "vue-style-loader": {
       "version": "4.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-style-loader/download/vue-style-loader-4.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-style-loader/download/vue-style-loader-4.1.2.tgz",
       "integrity": "sha1-3t80mAbyXOtOZPOtfApE+6c1/Pg=",
       "dev": true,
       "requires": {
@@ -32468,7 +32468,7 @@
       "dependencies": {
         "hash-sum": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.taobao.org/hash-sum/download/hash-sum-1.0.2.tgz",
+          "resolved": "https://registry.npmmirror.com/hash-sum/download/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
         }
@@ -32486,7 +32486,7 @@
     },
     "vue-template-es2015-compiler": {
       "version": "1.9.1",
-      "resolved": "https://registry.npm.taobao.org/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha1-HuO8mhbsv1EYvjNLsV+cRvgvWCU=",
       "dev": true
     },
@@ -32666,7 +32666,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "https://registry.npm.taobao.org/wbuf/download/wbuf-1.7.3.tgz",
+      "resolved": "https://registry.npmmirror.com/wbuf/download/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "dev": true,
       "requires": {
@@ -32734,7 +32734,7 @@
     },
     "webpack-bundle-analyzer": {
       "version": "3.9.0",
-      "resolved": "https://registry.npm.taobao.org/webpack-bundle-analyzer/download/webpack-bundle-analyzer-3.9.0.tgz?cache=0&sync_timestamp=1611221513167&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-bundle-analyzer%2Fdownload%2Fwebpack-bundle-analyzer-3.9.0.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-bundle-analyzer/download/webpack-bundle-analyzer-3.9.0.tgz?cache=0&sync_timestamp=1611221513167&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-bundle-analyzer%2Fdownload%2Fwebpack-bundle-analyzer-3.9.0.tgz",
       "integrity": "sha1-9vlNsQj7V05BWtMT3kGicH0z7zw=",
       "dev": true,
       "requires": {
@@ -32755,7 +32755,7 @@
       "dependencies": {
         "acorn": {
           "version": "7.4.1",
-          "resolved": "https://registry.npm.taobao.org/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
+          "resolved": "https://registry.npmmirror.com/acorn/download/acorn-7.4.1.tgz?cache=0&sync_timestamp=1611561275462&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Facorn%2Fdownload%2Facorn-7.4.1.tgz",
           "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
           "dev": true
         },
@@ -32772,7 +32772,7 @@
     },
     "webpack-chain": {
       "version": "6.5.1",
-      "resolved": "https://registry.npm.taobao.org/webpack-chain/download/webpack-chain-6.5.1.tgz?cache=0&sync_timestamp=1595813261846&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-chain%2Fdownload%2Fwebpack-chain-6.5.1.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-chain/download/webpack-chain-6.5.1.tgz?cache=0&sync_timestamp=1595813261846&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-chain%2Fdownload%2Fwebpack-chain-6.5.1.tgz",
       "integrity": "sha1-TycoTLu2N+PI+970Pu9YjU2GEgY=",
       "dev": true,
       "requires": {
@@ -32782,7 +32782,7 @@
     },
     "webpack-dev-middleware": {
       "version": "3.7.3",
-      "resolved": "https://registry.npm.taobao.org/webpack-dev-middleware/download/webpack-dev-middleware-3.7.3.tgz?cache=0&sync_timestamp=1610718844043&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-dev-middleware%2Fdownload%2Fwebpack-dev-middleware-3.7.3.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-dev-middleware/download/webpack-dev-middleware-3.7.3.tgz?cache=0&sync_timestamp=1610718844043&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-dev-middleware%2Fdownload%2Fwebpack-dev-middleware-3.7.3.tgz",
       "integrity": "sha1-Bjk3KxQyYuK4SrldO5GnWXBhwsU=",
       "dev": true,
       "requires": {
@@ -32836,7 +32836,7 @@
       "dependencies": {
         "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://registry.npm.taobao.org/anymatch/download/anymatch-2.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/anymatch/download/anymatch-2.0.0.tgz",
           "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
           "dev": true,
           "requires": {
@@ -32846,7 +32846,7 @@
           "dependencies": {
             "normalize-path": {
               "version": "2.1.1",
-              "resolved": "https://registry.npm.taobao.org/normalize-path/download/normalize-path-2.1.1.tgz",
+              "resolved": "https://registry.npmmirror.com/normalize-path/download/normalize-path-2.1.1.tgz",
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
@@ -32857,7 +32857,7 @@
         },
         "binary-extensions": {
           "version": "1.13.1",
-          "resolved": "https://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.13.1.tgz?cache=0&sync_timestamp=1610299268308&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbinary-extensions%2Fdownload%2Fbinary-extensions-1.13.1.tgz",
+          "resolved": "https://registry.npmmirror.com/binary-extensions/download/binary-extensions-1.13.1.tgz?cache=0&sync_timestamp=1610299268308&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbinary-extensions%2Fdownload%2Fbinary-extensions-1.13.1.tgz",
           "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
           "dev": true
         },
@@ -32883,7 +32883,7 @@
         },
         "fsevents": {
           "version": "1.2.13",
-          "resolved": "https://registry.npm.taobao.org/fsevents/download/fsevents-1.2.13.tgz",
+          "resolved": "https://registry.npmmirror.com/fsevents/download/fsevents-1.2.13.tgz",
           "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
           "dev": true,
           "optional": true,
@@ -32894,7 +32894,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://registry.npm.taobao.org/glob-parent/download/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/glob-parent/download/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -32904,7 +32904,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://registry.npm.taobao.org/is-glob/download/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmmirror.com/is-glob/download/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -32915,13 +32915,13 @@
         },
         "is-absolute-url": {
           "version": "3.0.3",
-          "resolved": "https://registry.npm.taobao.org/is-absolute-url/download/is-absolute-url-3.0.3.tgz",
+          "resolved": "https://registry.npmmirror.com/is-absolute-url/download/is-absolute-url-3.0.3.tgz",
           "integrity": "sha1-lsaiK2ojkpsR6gr7GDbDatSl1pg=",
           "dev": true
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.taobao.org/is-binary-path/download/is-binary-path-1.0.1.tgz",
+          "resolved": "https://registry.npmmirror.com/is-binary-path/download/is-binary-path-1.0.1.tgz",
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
@@ -32930,13 +32930,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/isarray/download/isarray-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/isarray/download/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.7",
-          "resolved": "https://registry.npm.taobao.org/readable-stream/download/readable-stream-2.3.7.tgz",
+          "resolved": "https://registry.npmmirror.com/readable-stream/download/readable-stream-2.3.7.tgz",
           "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
           "dev": true,
           "requires": {
@@ -32951,7 +32951,7 @@
         },
         "readdirp": {
           "version": "2.2.1",
-          "resolved": "https://registry.npm.taobao.org/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1602584394621&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
+          "resolved": "https://registry.npmmirror.com/readdirp/download/readdirp-2.2.1.tgz?cache=0&sync_timestamp=1602584394621&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freaddirp%2Fdownload%2Freaddirp-2.2.1.tgz",
           "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
           "dev": true,
           "requires": {
@@ -32962,7 +32962,7 @@
         },
         "schema-utils": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
+          "resolved": "https://registry.npmmirror.com/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1601922425223&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
           "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
           "dev": true,
           "requires": {
@@ -32973,13 +32973,13 @@
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npm.taobao.org/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
+          "resolved": "https://registry.npmmirror.com/semver/download/semver-6.3.0.tgz?cache=0&sync_timestamp=1606854493763&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsemver%2Fdownload%2Fsemver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmmirror.com/string_decoder/download/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
@@ -32988,7 +32988,7 @@
         },
         "supports-color": {
           "version": "6.1.0",
-          "resolved": "https://registry.npm.taobao.org/supports-color/download/supports-color-6.1.0.tgz",
+          "resolved": "https://registry.npmmirror.com/supports-color/download/supports-color-6.1.0.tgz",
           "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
           "dev": true,
           "requires": {
@@ -33018,7 +33018,7 @@
     },
     "webpack-merge": {
       "version": "4.2.2",
-      "resolved": "https://registry.npm.taobao.org/webpack-merge/download/webpack-merge-4.2.2.tgz?cache=0&sync_timestamp=1608705461067&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-merge%2Fdownload%2Fwebpack-merge-4.2.2.tgz",
+      "resolved": "https://registry.npmmirror.com/webpack-merge/download/webpack-merge-4.2.2.tgz?cache=0&sync_timestamp=1608705461067&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fwebpack-merge%2Fdownload%2Fwebpack-merge-4.2.2.tgz",
       "integrity": "sha1-onxS6ng9E5iv0gh/VH17nS9DY00=",
       "dev": true,
       "requires": {
@@ -33045,7 +33045,7 @@
     },
     "websocket-driver": {
       "version": "0.7.4",
-      "resolved": "https://registry.npm.taobao.org/websocket-driver/download/websocket-driver-0.7.4.tgz",
+      "resolved": "https://registry.npmmirror.com/websocket-driver/download/websocket-driver-0.7.4.tgz",
       "integrity": "sha1-ia1Slbv2S0gKvLox5JU6ynBvV2A=",
       "dev": true,
       "requires": {
@@ -33056,7 +33056,7 @@
     },
     "websocket-extensions": {
       "version": "0.1.4",
-      "resolved": "https://registry.npm.taobao.org/websocket-extensions/download/websocket-extensions-0.1.4.tgz",
+      "resolved": "https://registry.npmmirror.com/websocket-extensions/download/websocket-extensions-0.1.4.tgz",
       "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI=",
       "dev": true
     },


### PR DESCRIPTION
#465

替换新淘宝镜像地址

1. 将package-lock.json里的https://registry.npm.taobao.org/ 批量替换为https://registry.npmmirror.com/
2. .npmrc里配置了新的淘宝镜像